### PR TITLE
add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ We recommend that you clone all the repositories into one directory
 |-----------------|--------|----|
 | ensembl | default | https://github.com/Ensembl/ensembl.git |
 | ensembl-analysis | default | https://github.com/Ensembl/ensembl-analysis.git |
+| ensembl-io | default | https://github.com/Ensembl/ensembl-io.git |
 
 
 ## Running the pipeline


### PR DESCRIPTION
ensembl-io (https://github.com/Ensembl/ensembl-io) is also needed to run the pipeline (for Bio/EnsEMBL/Utils/IO/FASTASerializer.pm)