### PR TITLE
Update nextflow.config to introduce SLURM improvements and reduce duplication

### DIFF
--- a/modules/busco_dataset.nf
+++ b/modules/busco_dataset.nf
@@ -19,7 +19,7 @@
 process BUSCO_DATASET {
   scratch false
   label 'default'
-  tag "$db.species"
+  tag "$db.species:$db.gca"
    
   input:
   val(db)

--- a/modules/busco_genome_lineage.nf
+++ b/modules/busco_genome_lineage.nf
@@ -18,7 +18,7 @@
 // run Busco in genome mode 
 process BUSCO_GENOME_LINEAGE {
   label "busco"
-  tag "$db.species"
+  tag "$db.species:$db.gca"
 
   input:
   tuple val(db), val(busco_dataset), path(genome)

--- a/modules/busco_output.nf
+++ b/modules/busco_output.nf
@@ -19,7 +19,7 @@ include { make_publish_dir } from './utils.nf'
 
 process BUSCO_OUTPUT {
     // rename busco summary file in <production name>_gca_busco_short_summary.txt
-    tag "$db.species-$datatype"
+    tag "$db.species:$db.gca"
     label 'default'
     publishDir { make_publish_dir(db.publish_dir, project, 'statistics') },  mode: 'copy'
 

--- a/modules/busco_protein_lineage.nf
+++ b/modules/busco_protein_lineage.nf
@@ -18,7 +18,7 @@
 // run Busco in protein mode 
 process BUSCO_PROTEIN_LINEAGE {
   label 'busco'
-  tag "$db.species"
+  tag "$db.species:$db.gca"
 
   input:
   tuple val(db), val(busco_dataset), path(translations)

--- a/modules/fasta_output.nf
+++ b/modules/fasta_output.nf
@@ -21,7 +21,7 @@ include { make_publish_dir } from './utils.nf'
 
 // dump unmasked dna sequences from core db 
 process FASTA_OUTPUT {
-  tag "$db.species"
+  tag "$db.species:$db.gca"
   label "default"
   publishDir { make_publish_dir(db.publish_dir, project, name) },  mode: 'copy'
 

--- a/modules/fetch_genome.nf
+++ b/modules/fetch_genome.nf
@@ -37,8 +37,8 @@ process FETCH_GENOME {
   perl ${params.enscode}/ensembl-analysis/scripts/sequence_dump.pl \
     -dbhost ${params.host} \
     -dbport ${params.port} \
-    -dbname ${db.name} -dbuser \
-    ${params.user} \
+    -dbname ${db.name} \
+    -dbuser ${params.user} \
     -coord_system_name toplevel \
     -toplevel \
     -onefile \

--- a/modules/fetch_genome.nf
+++ b/modules/fetch_genome.nf
@@ -19,7 +19,7 @@
 
 // dump unmasked dna sequences from core db 
 process FETCH_GENOME {
-  tag "$db.species"
+  tag "$db.species:$db.gca"
   label "fetch_file"
   storeDir "$cache_dir/${db.name}/genome/"
   afterScript "sleep $params.files_latency"  // Needed because of file system latency

--- a/modules/fetch_proteins.nf
+++ b/modules/fetch_proteins.nf
@@ -17,7 +17,7 @@
 
 // Dump canonical translations 
 process FETCH_PROTEINS {
-  tag "$db.species"
+  tag "$db.species:$db.gca"
   label 'fetch_file'
   storeDir "$cache_dir/${db.name}/protein/"
   afterScript "sleep $params.files_latency"  // Needed because of file system latency

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,30 +23,33 @@
 ----------------------------------------------------------------------------------------
 */
 
+// Set minimum required Nextflow version, stopping execution if current version does not match
+nextflowVersion = '!>=23.01'
+
 // Global default params, used in configs
 params {
-  // Input options
-  csvFile = ''
+    // Input options
+    csvFile = ''
 
-  // db connection
-  host = ''
-  port = ''
-  user = ''
+    // db connection
+    host = ''
+    port = ''
+    user = ''
 
-  enscode = ''
-  bioperl = "${params.enscode}/bioperl-1.6.924"
+    enscode = ''
+    bioperl = "${params.enscode}/bioperl-1.6.924"
 
-  help = false
+    help = false
 
-  outDir = ''
-  files_latency = '60'
-  project = 'ensembl'
+    outDir = ''
+    files_latency = '60'
+    project = 'ensembl'
 }
 
 env {
-  ENSCODE = "${params.enscode}"
-  PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:" +
-    "${params.enscode}/ensembl-io/modules:${params.bioperl}:$PERL5LIB"
+    ENSCODE = "${params.enscode}"
+    PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:" +
+        "${params.enscode}/ensembl-io/modules:${params.bioperl}:$PERL5LIB"
 }
 
 scratch = ''
@@ -55,58 +58,72 @@ workDir = ''
 // Load assembly-checker config
 includeConfig 'conf/busco.config'
 
+singularity {
+    enabled = true
+    autoMounts = true
+    pullTimeout = '1 hour'
+}
+
 profiles {
 
-  local {
-    process.executor = 'local'
-    withLabel: 'default' {
-      cpus = 1
-      memory = { 1.GB * task.attempt }
-      time = { 1.h * task.attempt }
+    standard {
+        executor {
+            name = 'lsf'
+            perJobMemLimit = true
+            queueSize = 2000
+            submitRateLimit = "10/1sec"
+            queueGlobalStatus = true
+            exitReadTimeout = "30 min"
+        }
+
+        process {
+            queue = 'production'
+        }
     }
-  }
 
-  standard {
-    process.executor = 'LSF'
-    process.queue = 'production'
-    singularity.enabled = true
-    singularity.autoMounts = true
-    perJobMemLimit = true
-    errorStrategy = { task.exitStatus == 140 ? 'retry' : 'terminate' }
-    maxRetries = 3
-  }
+    slurm {
+        executor {
+            name = 'slurm'
+            queueSize = 2000
+            submitRateLimit = "10/1sec"
+            queueGlobalStatus = true
+            exitReadTimeout = "30 min"
+        }
 
-  slurm {
-    process.executor = 'slurm'
-    process.queue = 'standard'
-    singularity.enabled = true
-    singularity.autoMounts = true
-    perJobMemLimit = true
-    errorStrategy = { task.exitStatus == 140 ? 'retry' : 'terminate' }
-    clusterOptions = '-t 24:00:00 -e errlog.txt'
-    maxRetries = 3
-  }
+        process {
+            clusterOptions = '-t 24:00:00 -e errlog.txt'
+        }
+    }
+
+    local {
+        process.executor = 'local'
+    }
+
 }
 
 process {
-  withLabel: 'default' {
-    cpus = 1
-    memory = { 3.GB * task.attempt }
-    time = { 1.h * task.attempt }
-  }
-  withLabel: 'busco' {
-    cpus = 40
-    memory = { 40.GB * task.attempt }
-    time = { 4.h * task.attempt }
+    errorStrategy = { task.exitStatus == 140 ? 'retry' : 'terminate' }
+    maxRetries = 3
+    cache = 'lenient'
 
-    module = 'singularity-3.7.0-gcc-9.3.0-dp5ffrp'
-    container = "ezlabgva/busco:${params.busco_version}"
-  }
-  withLabel: 'fetch_file' {
-    cpus = 1
-    memory = { 8.GB * task.attempt }
-    time = { 2.h * task.attempt }
-  }
+    withLabel: 'default' {
+        cpus = 1
+        memory = { 3.GB * task.attempt }
+        time = { 1.h * task.attempt }
+    }
+    withLabel: 'busco' {
+        cpus = 40
+        memory = { 40.GB * task.attempt }
+        time = { 4.h * task.attempt }
+
+        module = 'singularity-3.7.0-gcc-9.3.0-dp5ffrp'
+        container = "ezlabgva/busco:${params.busco_version}"
+    }
+    withLabel: 'fetch_file' {
+        cpus = 1
+        memory = { 8.GB * task.attempt }
+        time = { 2.h * task.attempt }
+    }
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,7 +45,8 @@ params {
 
 env {
   ENSCODE = "${params.enscode}"
-  PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:${params.enscode}/ensembl-io/modules:${params.bioperl}"
+  PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:" +
+    "${params.enscode}/ensembl-io/modules:${params.bioperl}:$PERL5LIB"
 }
 
 scratch = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,28 +28,28 @@ nextflowVersion = '!>=23.01'
 
 // Global default params, used in configs
 params {
-    // Input options
-    csvFile = ''
+  // Input options
+  csvFile = ''
 
-    // db connection
-    host = ''
-    port = ''
-    user = ''
+  // db connection
+  host = ''
+  port = ''
+  user = ''
 
-    enscode = ''
-    bioperl = "${params.enscode}/bioperl-1.6.924"
+  enscode = ''
+  bioperl = "${params.enscode}/bioperl-1.6.924"
 
-    help = false
+  help = false
 
-    outDir = ''
-    files_latency = '60'
-    project = 'ensembl'
+  outDir = ''
+  files_latency = '60'
+  project = 'ensembl'
 }
 
 env {
-    ENSCODE = "${params.enscode}"
-    PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:" +
-        "${params.enscode}/ensembl-io/modules:${params.bioperl}:$PERL5LIB"
+  ENSCODE = "${params.enscode}"
+  PERL5LIB = "${params.enscode}/ensembl/modules:${params.enscode}/ensembl-analysis/modules:" +
+    "${params.enscode}/ensembl-io/modules:${params.bioperl}:$PERL5LIB"
 }
 
 scratch = ''
@@ -59,71 +59,71 @@ workDir = ''
 includeConfig 'conf/busco.config'
 
 singularity {
-    enabled = true
-    autoMounts = true
-    pullTimeout = '1 hour'
+  enabled = true
+  autoMounts = true
+  pullTimeout = '1 hour'
 }
 
 profiles {
 
-    standard {
-        executor {
-            name = 'lsf'
-            perJobMemLimit = true
-            queueSize = 2000
-            submitRateLimit = "10/1sec"
-            queueGlobalStatus = true
-            exitReadTimeout = "30 min"
-        }
-
-        process {
-            queue = 'production'
-        }
+  standard {
+    executor {
+      name = 'lsf'
+      perJobMemLimit = true
+      queueSize = 2000
+      submitRateLimit = "10/1sec"
+      queueGlobalStatus = true
+      exitReadTimeout = "30 min"
     }
 
-    slurm {
-        executor {
-            name = 'slurm'
-            queueSize = 2000
-            submitRateLimit = "10/1sec"
-            queueGlobalStatus = true
-            exitReadTimeout = "30 min"
-        }
+    process {
+      queue = 'production'
+    }
+  }
 
-        process {
-            clusterOptions = '-t 24:00:00 -e errlog.txt'
-        }
+  slurm {
+    executor {
+      name = 'slurm'
+      queueSize = 2000
+      submitRateLimit = "10/1sec"
+      queueGlobalStatus = true
+      exitReadTimeout = "30 min"
     }
 
-    local {
-        process.executor = 'local'
+    process {
+      clusterOptions = '-t 24:00:00 -e errlog.txt'
     }
+  }
+
+  local {
+    process.executor = 'local'
+  }
 
 }
 
 process {
-    errorStrategy = { task.exitStatus == 140 ? 'retry' : 'terminate' }
-    maxRetries = 3
-    cache = 'lenient'
+  errorStrategy = { task.exitStatus == 140 ? 'retry' : 'terminate' }
+  maxRetries = 3
+  cache = 'lenient'
 
-    withLabel: 'default' {
-        cpus = 1
-        memory = { 3.GB * task.attempt }
-        time = { 1.h * task.attempt }
-    }
-    withLabel: 'busco' {
-        cpus = 40
-        memory = { 40.GB * task.attempt }
-        time = { 4.h * task.attempt }
+  withLabel: 'default' {
+    cpus = 1
+    memory = { 3.GB * task.attempt }
+    time = { 1.h * task.attempt }
+  }
+  withLabel: 'busco' {
+    cpus = 40
+    memory = { 40.GB * task.attempt }
+    time = { 4.h * task.attempt }
 
-        module = 'singularity-3.7.0-gcc-9.3.0-dp5ffrp'
-        container = "ezlabgva/busco:${params.busco_version}"
-    }
-    withLabel: 'fetch_file' {
-        cpus = 1
-        memory = { 8.GB * task.attempt }
-        time = { 2.h * task.attempt }
-    }
+    module = 'singularity-3.7.0-gcc-9.3.0-dp5ffrp'
+    container = "ezlabgva/busco:${params.busco_version}"
+  }
+  withLabel: 'fetch_file' {
+    cpus = 1
+    memory = { 8.GB * task.attempt }
+    time = { 2.h * task.attempt }
+  }
 
 }
 


### PR DESCRIPTION
_Note:_ All the following changes have been tested both in SLURM and LSF. The pipeline is now capable of handling 74 species in one go without any issues, and it has taken a little bit less than 5 hours (Docker was already present).

### Update nextflow.config
EBI's TSC is working in a new document on settings that will help with running Nextflow pipelines in SLURM. They have shared the main elements with me so I have taken the opportunity to introduce them as well as try to update the configuration file to the latest standards, reducing duplication where possible. The main drawback is that we have now to set the minimum Nextflow version to 23.01.

### Make process tags more informative
During testing of the pipeline I thought Nextflow was submitting the same job several times because the process tag only included the species name and my list contained several genomes for the same species. Adding the GCA to the process tag will reduce the chances of someone getting confused as well in the future (whilst preserving the readability of the species name).

### Bugfix on PERL5LIB env var
Under certain conditions Nextflow will not be able to find the installed `cpan` libraries. As an example, the error I had before applying this fix was:
```
Command error:                                                                                                                                                                                     
  Can't locate DBI.pm in @INC (...
```
which was present as part of the paths of my environment `$PERL5LIB` (so running `perl -e "use DBI;"` did not raise an error), but it was lost when executing Nextflow.