### PR TITLE
Update BUSCO to the latest stable version

### DIFF
--- a/conf/busco.config
+++ b/conf/busco.config
@@ -24,7 +24,7 @@
 */
 
 params {
-        busco_version = 'v5.3.2_cv1'
+        busco_version = 'v5.4.7_cv1'
         download_path = '/nfs/production/flicek/ensembl/genebuild/genebuild_virtual_user/data/busco_data/data'
         mode = ['protein', 'genome']
 


### PR DESCRIPTION
There is an edge case that was not fixed until 10 months and I have encountered the same issue whilst producing BUSCO score for VEuPathDB species. For more details: https://gitlab.com/ezlab/busco/-/issues/592.