### PR TITLE
Bugfix: remove setuptools directives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,6 @@ repository = "https://github.com/Ensembl/ensembl-genes-nf"
 [project.scripts]
 #run_fastqc = "ensembl.genes.metadata.qc.run_fastqc:main"
 
-[tool.setuptools]
-package-dir = {"" = "src"}
-
-
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [ 
@@ -74,8 +70,6 @@ requires = [
     "setuptools-scm",
     "wheel"
 ]
-[tool.setuptools.packages.find]
-where = ["src/python"]
 
 [tool.black]
 line-length = 110
@@ -94,7 +88,6 @@ disable = [
 ]
 
 [tool.mypy]
-mypy_path = "src"
 explicit_package_bases = true
 ignore_missing_imports = true
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ readme = "README.md"
 authors = [
     {name = "Ensembl", email = "dev@ensembl.org"},
 ]
-license = {text = "Apache License 2.0"}
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 keywords = ["ensembl", 
 "annotation", 
 "genetics",
@@ -32,7 +33,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Bio-Informatics",


### PR DESCRIPTION
Required so when using this repository in modenv setuptools does not think this is a Python library and the `src` folder is missing, raising an error.

I have taken the opportunity to update the license information following the latest expression update (https://peps.python.org/pep-0639/).