### PR TITLE
change singularity cache

### DIFF
--- a/pipelines/statistics/nextflow.config
+++ b/pipelines/statistics/nextflow.config
@@ -67,22 +67,14 @@ params {
   help = false
 
   cacheDir = "${params.outdir}/cache"
-  singularityCacheDir = "${params.cacheDir}/singularity"
   files_latency = 60
   cleanCache = false // Default to false
 }
 
-singularity {
-  cacheDir = params.singularityCacheDir
-  enabled = true
-  autoMounts = true
-  pullTimeout = '2 hour'
-}
 
 profiles {
 
   standard {
-    singularity.cacheDir = params.singularityCacheDir
     singularity.autoMounts = true
 
     executor {


### PR DESCRIPTION
Singularity cache was hardcoded into results/cache. I deleted it to let the base config handle it and download to the correct folder.

Delete if this is not the intended behaviour