### PR TITLE
Strict Syntax, QC container and manifest validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ The example pipeline demonstrates patterns from simple to complex:
 - Nextflow ≥ 21.04.0 (DSL2)
 - Singularity 
 
+## Private Container Registry
+
+Some implementation pipelines use private images from the EBI Docker registry.
+Authenticate Singularity or Apptainer outside Nextflow with an EBI/GitLab
+account or token that has registry-read permission:
+
+```bash
+read -s EBI_REGISTRY_TOKEN
+printf '%s\n' "$EBI_REGISTRY_TOKEN" | singularity registry login \
+  --username "$EBI_REGISTRY_USER" \
+  --password-stdin \
+  docker://dockerhub.ebi.ac.uk
+unset EBI_REGISTRY_TOKEN
+```
+
+Check access before launching a pipeline:
+
+```bash
+singularity registry list
+singularity pull docker://dockerhub.ebi.ac.uk/<project>/<image>:<tag>
+```
+
+For CI, use masked `APPTAINER_DOCKER_USERNAME` and
+`APPTAINER_DOCKER_PASSWORD` secrets. Never put registry credentials in a
+sample sheet, Nextflow parameter, or committed configuration file.
+
 ## Branch Structure
 
 - **`template`** (this branch) - Templates, examples, and documentation
@@ -121,4 +147,3 @@ Contributions to improve templates and documentation are welcome! Consider:
 ## License
 
 [Add license information]
-

--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ Authenticate Singularity or Apptainer outside Nextflow with an EBI/GitLab
 account or token that has registry-read permission:
 
 ```bash
-read -s EBI_REGISTRY_TOKEN
+export EBI_REGISTRY_USER="${EBI_REGISTRY_USER:-$USER}"
+read -r -s EBI_REGISTRY_TOKEN
+printf '\n'
 printf '%s\n' "$EBI_REGISTRY_TOKEN" | singularity registry login \
   --username "$EBI_REGISTRY_USER" \
   --password-stdin \

--- a/nextflow.config
+++ b/nextflow.config
@@ -70,11 +70,10 @@ dag {
     overwrite = true
 }
 
-// I had this in a profile but decided it should be the default and can be overwritten with profiles
-// if we want to support non-cluster execution with Docker/Conda
+// Keep Singularity enabled by default while allowing the cache location to be
+// supplied by NXF_SINGULARITY_CACHEDIR or Nextflow's default behavior.
 singularity {
     enabled = true
     autoMounts = false  // Disable to prevent home directory contamination
-    cacheDir = '/nfs/production/flicek/ensembl/shared_data/singularity_images/cache'
     runOptions = '--cleanenv'  // Clean environment to avoid local package interference
 }

--- a/pipelines/qc/README.md
+++ b/pipelines/qc/README.md
@@ -88,11 +88,18 @@ The QC parser image is private in the EBI Docker registry. Authenticate
 Apptainer once on the execution host using an EBI/GitLab account or token with
 permission to read the registry:
 
+Enter the token interactively and pipe it to the login command. The token is
+never placed on the command line or stored in the repository:
+
 ```bash
-singularity registry login \
+export EBI_REGISTRY_USER="${EBI_REGISTRY_USER:-$USER}"
+read -r -s EBI_REGISTRY_TOKEN
+printf '\n'
+printf '%s\n' "$EBI_REGISTRY_TOKEN" | singularity registry login \
   --username "$EBI_REGISTRY_USER" \
   --password-stdin \
   docker://dockerhub.ebi.ac.uk
+unset EBI_REGISTRY_TOKEN
 ```
 
 Verify the credentials and image access before starting Nextflow:

--- a/pipelines/qc/README.md
+++ b/pipelines/qc/README.md
@@ -1,107 +1,110 @@
 # QC Pipeline
 
-This pipeline runs annotation QC on one or more samples using AGAT statistics and, optionally, InterProScan-derived metrics.
-
-## What It Does
-
-For each row in the input CSV, the pipeline:
-
-1. runs `agat_sp_statistics.pl` on the GFF3 file
-2. parses the AGAT output into a `*_agat_stats_genebuild.csv` file
-3. optionally runs InterProScan on the protein FASTA
-4. optionally parses the InterProScan output into an InterPro metrics TSV
+This pipeline runs annotation QC from a genome FASTA and a GFF3 annotation. It
+can run AGAT metrics, InterProScan protein coverage, Diamond protein
+validation, or all three.
 
 ## Requirements
 
-- Nextflow 25.x
-- Singularity available on the execution host
-- InterProScan 5.78-109.0 data available on shared storage when the InterProScan branch is enabled
-- A local checkout of `ensembl-genes` containing:
-    - `src/python/ensembl/genes/annotation-qc/parsers/parse_agat.py`
-    - `src/python/ensembl/genes/annotation-qc/metrics/config/feature_levels.yaml`
-    - `src/python/ensembl/genes/annotation-qc/parsers/interpro.py` when `--run_interproscan` is enabled
+- Nextflow 26.04.6 or later (strict syntax)
+- Singularity or Apptainer
+- The InterProScan 5.78-109.0 data directory for `interproscan` and `combined`
+- A QC parser container exposing `annotation-qc parse-agat` and
+  `annotation-qc parse-interpro` when using AGAT or InterProScan
+- The pipeline supplies its Ensembl AGAT feature definitions internally
+- Registry credentials configured outside the pipeline if the GitLab registry
+  requires authentication
 
-## Inputs
+The parser image is assigned centrally to the `qc_parser` process label and
+currently uses the EBI Docker registry `:latest` image. Once the pipeline is
+versioned, change that single config reference to an immutable container tag
+based on the corresponding commit SHA.
 
-### Sample Sheet
+To select the Nextflow version explicitly, set `NXF_VER` before the command:
 
-The required input is `--input_csv`, a CSV file with a header and at least these columns:
-
-```csv
-sample,gff3,protein
-sample_1,/path/to/sample_1.gff3,/path/to/sample_1.faa
-sample_2,/path/to/sample_2.gff3,/path/to/sample_2.faa
+```bash
+NXF_VER=26.04.6 nextflow run pipelines/qc/main.nf --help
 ```
 
-- `sample`: sample identifier used for logging and task tags
-- `gff3`: path to the GFF3 file used by AGAT
-- `protein`: path to the protein FASTA used by InterProScan
+## Input
 
-If `--run_agat_metrics` is enabled, `gff3` must be present for every row.
-If `--run_interproscan` is enabled, `protein` must be present for every row.
+The annotation manifest contains the shared inputs needed to derive proteins:
+
+```csv
+sample,genome_fasta,gff3
+sample_1,/path/to/sample_1.fa,/path/to/sample_1.gff3
+sample_2,/path/to/sample_2.fa,/path/to/sample_2.gff3
+```
+
+An optional precomputed protein FASTA can be supplied for any row:
+
+```csv
+sample,genome_fasta,gff3,protein_fasta
+sample_1,/path/to/sample_1.fa,/path/to/sample_1.gff3,/path/to/sample_1.faa
+```
+
+AGAT consumes the GFF3 directly. InterProScan and Diamond use the supplied
+protein FASTA when present and otherwise consume a FASTA derived by `gffread`.
+Inputs that are not part of every annotation, such as splice-junction files,
+should be provided through their own manifest when a future QC workflow needs
+them.
+
+Diamond requires either a prebuilt database via `--diamond_reference_db` or a
+reference protein FASTA via `--diamond_reference_proteins`. The prebuilt
+database takes precedence and avoids rebuilding it. The FASTA is used only as
+the fallback source for `diamond makedb`.
 
 ## Parameters
 
-| Parameter              | Required | Default                                                                   | Description                               |
-| ---------------------- | -------- | ------------------------------------------------------------------------- | ----------------------------------------- |
-| `--input_csv`          | yes      | none                                                                      | CSV describing the samples and file paths |
-| `--ensembl_genes_repo` | yes      | none                                                                      | Path to a local `ensembl-genes` checkout  |
-| `--feature_levels`     | no       | derived from `ensembl_genes_repo`                                         | Path to `feature_levels.yaml`             |
-| `--agat_parser`        | no       | derived from `ensembl_genes_repo`                                         | Path to `parse_agat.py`                   |
-| `--run_agat_metrics`   | no       | `false`                                                                   | Enable the AGAT metrics branch            |
-| `--run_interproscan`   | no       | `false`                                                                   | Enable the InterProScan branch            |
-| `--database`           | no       | `Pfam`                                                                    | InterProScan application database         |
-| `--data_file_path`     | no       | `/nfs/production/flicek/ensembl/shared_data/interproscan-5.78-109.0/data` | Path to the InterProScan 5 data directory |
-| `--interpro_parser`    | no       | derived from `ensembl_genes_repo`                                         | Path to `interpro.py`                     |
-| `--outdir`             | no       | `./results`                                                               | Output directory                          |
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `--input_csv` | yes | CSV containing `sample`, `genome_fasta`, and `gff3` |
+| `--mode` | yes | `agat`, `interproscan`, `diamond`, or `combined` |
+| `--data_file_path` | InterProScan modes | InterProScan data directory |
+| `--diamond_reference_db` | Diamond modes | Existing prebuilt Diamond database; takes precedence over the FASTA |
+| `--diamond_reference_proteins` | Diamond modes | Reference protein FASTA used to build a database when no prebuilt database is supplied |
+| `--database` | no | InterProScan database, default `Pfam` |
+| `--outdir` | no | Output directory, default `./results` |
 
 ## Running
 
 ```bash
 nextflow run pipelines/qc/main.nf \
-  --input_csv /path/to/qc_samples.csv \
-  --ensembl_genes_repo /path/to/ensembl-genes \
-  --outdir results \
-  -profile slurm
-```
-
-To enable AGAT:
-
-```bash
-nextflow run pipelines/qc/main.nf \
-  --input_csv /path/to/qc_samples.csv \
-  --ensembl_genes_repo /path/to/ensembl-genes \
-  --run_agat_metrics \
-  --outdir results \
-  -profile slurm
-```
-
-To enable InterProScan:
-
-```bash
-nextflow run pipelines/qc/main.nf \
-  --input_csv /path/to/qc_samples.csv \
-  --ensembl_genes_repo /path/to/ensembl-genes \
-  --run_interproscan \
-  --database Pfam \
+  -profile slurm \
+  --input_csv /path/to/annotation_samples.csv \
+  --mode combined \
   --data_file_path /path/to/interproscan/data \
-  --outdir results \
-  -profile slurm
-```
-
-The `slurm` profile enables Singularity and runs the QC processes through Slurm. The InterProScan container is pulled from the Docker image `interpro/interproscan:5.78-109.0`; Docker itself is not required on the cluster.
-
-If the parsers or feature-level YAML are not present under the supplied `ensembl-genes` checkout, pass them explicitly:
-
-```bash
-nextflow run pipelines/qc/main.nf \
-  --input_csv /path/to/qc_samples.csv \
-  --ensembl_genes_repo /path/to/ensembl-genes \
-  --agat_parser /path/to/parse_agat.py \
-  --interpro_parser /path/to/interpro.py \
-  --feature_levels /path/to/feature_levels.yaml \
+  --diamond_reference_db /path/to/reference.dmnd \
   --outdir results
 ```
+
+Do not put registry usernames, passwords, or tokens in the sample sheet or
+Nextflow configuration. Configure Apptainer or Singularity authentication on
+the execution host before launching the run.
+
+## Registry Authentication
+
+The QC parser image is private in the EBI Docker registry. Authenticate
+Apptainer once on the execution host using an EBI/GitLab account or token with
+permission to read the registry:
+
+```bash
+singularity registry login \
+  --username "$EBI_REGISTRY_USER" \
+  --password-stdin \
+  docker://dockerhub.ebi.ac.uk
+```
+
+Verify the credentials and image access before starting Nextflow:
+
+```bash
+singularity registry list
+singularity pull docker://dockerhub.ebi.ac.uk/ensembl_genebuild/ensembl-genes-containers/ensembl-genes-qc-dev:latest
+```
+
+For CI or other non-interactive runs, provide masked secrets as
+`APPTAINER_DOCKER_USERNAME` and `APPTAINER_DOCKER_PASSWORD`. Do not pass
+registry credentials as Nextflow parameters or commit them to configuration.
 
 ## Outputs
 
@@ -110,38 +113,23 @@ Published outputs are written to:
 ```text
 <outdir>/qc/agat/
 <outdir>/qc/interpro/
+<outdir>/qc/diamond/
 ```
 
-Per sample, the pipeline currently produces:
+When Diamond builds a database from FASTA, the reusable database is also
+published as `<outdir>/qc/diamond/reference.dmnd` and can be supplied to a
+later run with `--diamond_reference_db`.
 
-- `<sample>_agat_stats.txt`: raw AGAT statistics output
-- `<sample>_agat_stats_genebuild.csv`: parsed AGAT metrics
-- `<sample>.tsv`: raw InterProScan TSV output
-- `<sample>_hits.tsv`: parsed InterPro metrics
+## Separation Of Concerns
 
+- `nextflow_schema.json` validates parameter types, enums, required mode-specific
+  inputs, and the annotation manifest schema.
+- `main.nf` loads validated inputs and starts the workflow.
+- `workflows/qc.nf` decides which analyses run and shares derived proteins.
+- Subworkflows connect reusable analysis chains.
+- Modules run one tool or parser and do not decide which QC mode the user chose.
 
-## Validation
-
-The workflow stops early if any of the following are missing or invalid:
-
-- `--input_csv`
-- `--ensembl_genes_repo`
-- derived or explicit `feature_levels.yaml`
-- derived or explicit `parse_agat.py`
-- derived or explicit `interpro.py` when `--run_interproscan` is enabled
-- sample rows missing `gff3` when AGAT is enabled
-- sample rows missing `protein` when InterProScan is enabled
-
-## Implementation Notes
-
-- The workflow entrypoint is `pipelines/qc/main.nf`.
-- AGAT statistics are implemented in `modules/agat/run_agat_stats.nf`.
-- AGAT report parsing is implemented in `modules/agat/parse_agat.nf`.
-- The AGAT subworkflow is defined in `subworkflows/agat/agat_stats.nf`.
-- InterProScan execution is implemented in `modules/interpro/run_interpro.nf`.
-- InterPro metrics parsing is implemented in `modules/interpro/interpro_stats.nf`.
-- The InterPro subworkflow is defined in `subworkflows/interpro/interproscan.nf`.
-
-## Current Scope
-
-This pipeline exposes AGAT metrics behind `--run_agat_metrics` and InterProScan metrics behind `--run_interproscan`.
+In short: **the schema validates configuration; workflow code resolves that
+configuration into behaviour.** This keeps reusable subworkflows independent
+of pipeline-specific parameter names and prevents one universal sample sheet
+from accumulating unrelated future inputs.

--- a/pipelines/qc/assets/annotation_samplesheet.json
+++ b/pipelines/qc/assets/annotation_samplesheet.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "sample": {
+        "type": "string",
+        "pattern": "^\\S+$"
+      },
+      "genome_fasta": {
+        "type": "string",
+        "format": "file-path",
+        "exists": true
+      },
+      "gff3": {
+        "type": "string",
+        "format": "file-path",
+        "exists": true
+      },
+      "protein_fasta": {
+        "type": "string",
+        "format": "file-path",
+        "exists": true,
+        "description": "Optional precomputed protein FASTA. If absent, proteins are derived with gffread."
+      }
+    },
+    "required": ["sample", "genome_fasta", "gff3"],
+    "additionalProperties": false
+  }
+}

--- a/pipelines/qc/assets/feature_levels.yaml
+++ b/pipelines/qc/assets/feature_levels.yaml
@@ -1,0 +1,221 @@
+# -----------------------------------------------------------------------------
+#                       FEATURE LEVEL DEFINITION FILE
+# -----------------------------------------------------------------------------
+
+# AGAT parser (_sp_ prefix scipts) handles the features (1 line = 1 feature where
+# the feature type is indicated within the 3rd column) only if the feature type is
+# declared within this file, otherwise it will be skipped.
+# Features must be linked to one and only one of the 3 available levels: leve1,
+# level2, level3. It depends is Parent or children are expected by the feature.
+# Please find more info in the corresponding section below.
+
+# Few features (e.g. CDS, UTR) can span multiple lines because are spread over
+# multiple locations within the genome while representing only one biological
+# concept. In such case you must also add the information (only if missing) in
+# the "spread feature "section
+
+# Some feature can require extra information. This extra information is added as
+# follow:
+# -feature: extra_information
+# In order to keep the file consistent, when no information is needed we put 1
+# as default value. This does not have any specific meaning.
+
+# ----------------------------------- LEVEL1 -----------------------------------
+# Level1 features are features without parent.
+# Level1 features with topfeature or standalone value do not expect children. It means they will not be removed if no sub-feature is linked to it.
+# Level1 features with standalone value will be sorted in the same way as other features e.g. by position in the sequence
+# Level1 features with topfeature value will not be sorted in the same way as other features e.g. all topfeature will be printed first in the sequence
+level1:
+  cacta_tir_transposon: standalone
+  cage_cluster: standalone
+  cdna_match: 1
+  centromere: standalone
+  chromosome: topfeature
+  conserved_region: standalone
+  contig: topfeature
+  crispr: standalone
+  dnasei_hypersensitive_site: standalone
+  enhancer: standalone
+  enhancer_blocking_element: standalone
+  epigenetically_modified_region: standalone
+  est_match: 1
+  expressed_sequence_match: 1
+  gene: 1
+  group_ii_intron: standalone
+  hat_tir_transposon: standalone
+  helitron: standalone
+  insulator: standalone
+  intergenic_region: standalone
+  inverted_repeat: standalone
+  knob: standalone
+  l1_line_retrotransposon: standalone
+  lincrna_gene: 1
+  locus_control_region: standalone
+  match: 1
+  matrix_attachment_site: standalone
+  meiotic_recombination_region: standalone
+  minisatellite: standalone
+  mirna_gene: 1
+  mobile_genetic_element: standalone
+  mutator_tir_transposon: standalone
+  ncrna_gene: 1
+  non_allelic_homologous_recombination_region: standalone
+  nucleotide_motif: 1
+  nucleotide_to_protein_match: 1
+  orf: 1
+  pif_harbinger_tir_transposon: standalone
+  pirna_gene: 1
+  polypeptide: 1
+  promoter: standalone
+  protein_binding_site: standalone
+  protein_coding_gene: 1
+  protein_match: 1
+  protein_bind: standalone
+  pseudogene: 1
+  pseudogenic_region: 1
+  region: topfeature
+  regulatory_region: standalone
+  regulatory: standalone
+  response_element: standalone
+  rrna_gene: 1
+  repeat_instability_region: standalone
+  repeat_region: standalone
+  sequence_alteration: standalone
+  sequence_comparison: standalone
+  sequence_feature: standalone
+  scaffold: topfeature
+  silencer: standalone
+  sirna_gene: 1
+  snorna_gene: 1
+  snrna_gene: 1
+  source: topfeature
+  sts: 1
+  subtelomere: standalone
+  tandem_repeat: standalone
+  tata_box: standalone
+  tc1_mariner_tir_transposon: standalone
+  transcriptional_cis_regulatory_region: standalone
+  translated_nucleotide_match: 1
+  transposable_element: 1
+  transposable_element_gene: 1
+  transposon_fragment: 1
+  biological_region: topfeature
+
+# ----------------------------------- LEVEL2 -----------------------------------
+# Level2 features are features with parent and potentially a child (e.g. match feature does not expect any child
+# Level2 feature values correspond to which parent type (level1 feature type) it is expected to be attached
+level2:
+  aberrant_processed_transcript: gene
+  antisense_rna: gene
+  antisense_lncrna: gene
+  c_gene_segment: gene
+  copia_ltr_retrotransposon: repeat_region
+  d_gene_segment: gene
+  gene_segment: gene
+  guide_rna: gene
+  gypsy_ltr_retrotransposon: repeat_region
+  j_gene_segment: gene
+  lcrna: gene
+  lincrna: gene
+  ltr/copia: repeat_region
+  long_terminal_repeat: repeat_region
+  lnc_rna: gene
+  lncrna: gene
+  ltr/copia: repeat_region
+  ltr_retrotransposon: repeat_region
+  match_part: match
+  nucleotide_to_protein_match_part: nucleotide_to_protein_match
+  mirna: gene
+  mirna_primary_transcript: gene
+  misc_rna: gene
+  mrna: gene
+  nc_primary_transcript: gene
+  ncrna: gene
+  nmd_transcript_variant: gene
+  pirna: pirna_gene
+  pre_mirna: gene
+  primary_transcript: gene
+  processed_pseudogene: pseudogene
+  processed_transcript: gene
+  pseudogenic_transcript: pseudogene
+  pseudogenic_trna: pseudogene
+  rna: gene
+  rnase_mrp_rna: gene
+  rnase_p_rna: gene
+  rrna: gene
+  scrna: gene
+  similarity: match
+  sirna_gene: gene
+  snorna: gene
+  snrna: gene
+  srp_rna: gene
+  target_site_duplication: repeat_region
+  tmrna: gene
+  transcript: gene
+  transcript_region: gene
+  trna: gene
+  trna_pseudogene: pseudogene
+  unconfirmed_transcript: gene
+  unitary_pseudogene: pseudogene
+  v_gene_segment: gene
+  vaultrna: gene
+  vaultrna_primary_transcript: gene
+  y_rna: ncrna_gene
+
+# ----------------------------------- LEVEL3 -----------------------------------
+# Level3 features have parents, but no children.
+# The value <exon> informs AGAT that the feature is part of an exon.
+level3:
+  cds: exon
+  exon: 1
+  five_prime_utr: exon
+  five_prime_cis_splice_site: 1
+  intron: 1
+  non_canonical_five_prime_splice_site: 1
+  non_canonical_three_prime_splice_site: 1
+  protein: 1
+  pseudogenic_exon: 1
+  pseudogenic_cds: pseudogenic_exon
+  selenocysteine: 1
+  sig_peptide: exon
+  splice3 : intron
+  splice5 : intron
+  start_codon: exon
+  stop_codon: exon
+  stop_codon_read_through: exon
+  three_prime_utr: exon
+  three_prime_cis_splice_site: 1
+  tss: exon
+  transcription_end_site: exon
+  transcription_start_site: exon
+  tts: exon
+  3utr: exon
+  3'-utr: exon
+  utr: exon
+  uorf: five_prime_utr
+  5utr: exon
+  5'-utr: exon
+
+# ------------------------------- SPREAD FEATURES ------------------------------
+# Here are described features that may span over different locations
+spread:
+   cds: 1
+   five_prime_utr: 1
+   pseudogenic_cds: 1
+   start_codon: 1
+   stop_codon: 1
+   three_prime_utr: 1
+   utr: 1
+   uorf: 1
+   3utr: 1
+   5utr: 1
+
+
+# features from level3 to not merge when overlap.
+# By default level3 features (children of the same parent) that overlap are merged.
+# the check_all_level3_locations step take care of that. This behaviour is
+# deactivated force the features listed below.
+# It is possible to modify the behaviour for all level3 feature types via the
+# agat config file : agat config --expose --no-check_all_level3_locations
+skip_merge_l3:
+  uorf: 1

--- a/pipelines/qc/main.nf
+++ b/pipelines/qc/main.nf
@@ -1,167 +1,26 @@
 #!/usr/bin/env nextflow
 
-include { validateParameters } from 'plugin/nf-schema'
-include { AGAT_METRICS } from './subworkflows/agat/agat_stats.nf'
-include { INTERPRO_SCAN } from './subworkflows/interpro/interproscan.nf'
-
-def validate_params() {
-    def errors = []
-    def repoRoot = params.ensembl_genes_repo ? file(params.ensembl_genes_repo) : null
-    def defaultFeatureLevelsPath = "${repoRoot}/src/python/ensembl/genes/annotation_qc/config/feature_levels.yaml"
-
-    if (!params.input_csv)
-        errors << "  --input_csv is required"
-    else if (!file(params.input_csv).exists())
-        errors << "  --input_csv does not exist: ${params.input_csv}"
-
-    if (!params.ensembl_genes_repo)
-        errors << "  --ensembl_genes_repo is required"
-    else if (!file(params.ensembl_genes_repo).exists())
-        errors << "  --ensembl_genes_repo does not exist: ${params.ensembl_genes_repo}"
-
-    if (params.run_agat_metrics) {
-
-        if (params.feature_levels) {
-            if (!file(params.feature_levels).exists())
-                errors << "--feature_levels does not exist: ${params.feature_levels}"
-        }
-        else if (repoRoot) {
-            def defaultFeatureLevels = file(defaultFeatureLevelsPath)
-            if (!defaultFeatureLevels.exists())
-                errors << "feature_levels.yaml not found under --ensembl_genes_repo; pass --feature_levels explicitly or point --ensembl_genes_repo to a checkout containing it"
-        }
-
-        if (params.agat_parser) {
-            if (!file(params.agat_parser).exists())
-                errors << "--agat_parser does not exist: ${params.agat_parser}"
-        }
-    }
-
-    def allowed_dbs = [
-        'TIGRFAM',
-        'SFLD',
-        'SUPERFAMILY',
-        'PANTHER',
-        'Gene3D',
-        'Hamap',
-        'ProSiteProfiles',
-        'Coils',
-        'SMART',
-        'CDD',
-        'PRINTS',
-        'PIRSR',
-        'ProSitePatterns',
-        'AntiFam',
-        'Pfam',
-        'MobiDBLite',
-        'PIRSF'
-    ]
-
-    if (params.run_interproscan) {
-        if (params.data_file_path) {
-            if (!file(params.data_file_path).exists())
-                errors << "  --data_file_path does not exist: ${params.data_file_path}"
-        }
-
-        if (params.interpro_parser) {
-            if (!file(params.interpro_parser).exists())
-                errors << "  --interpro_parser does not exist: ${params.interpro_parser}"
-        }
-
-        if (params.database == null || params.database.toString().trim().isEmpty())
-            errors << "  --database is required when --run_interproscan is enabled"
-
-        if (!(params.database in allowed_dbs)) {
-            errors << "--database must be one of: ${allowed_dbs.join(', ')}"
-        }
-    }
-
-    if (errors) {
-        error "Missing or invalid parameters:\n${errors.join('\n')}"
-    }
-}
+include { validateParameters; samplesheetToList } from 'plugin/nf-schema'
+include { QC } from './workflows/qc.nf'
 
 workflow {
-
+    // nf-schema validates the parameter and annotation manifest contracts.
     validateParameters()
-    println "run_agat_metrics = ${params.run_agat_metrics}"
-    println "run_interproscan = ${params.run_interproscan}"
-    validate_params()
 
-    /*
-     * Read CSV with columns: sample,gff3,protein
-     */
-    Channel
-        .fromPath(params.input_csv, checkIfExists: true)
-        .splitCsv(header: true)
-        .map { row ->
+    // This is pipeline-owned configuration, not a user-supplied input.
+    feature_levels_yaml = file("${projectDir}/assets/feature_levels.yaml")
 
-            def meta = [
-                id     : row.sample,
-                sample : row.sample
-            ]
+    annotation_ch = channel.fromList(
+        samplesheetToList(params.input_csv, 'assets/annotation_samplesheet.json')
+    )
 
-            def gff_path = row.gff3 ? file(row.gff3, checkIfExists: true) : null
-            def protein_path = row.protein ? file(row.protein, checkIfExists: true) : null
-
-            if (gff_path)
-                meta.gff3 = gff_path.name
-
-            if (protein_path)
-                meta.protein = protein_path.name
-
-            if (params.run_agat_metrics && !gff_path)
-                error "Sample ${row.sample} is missing gff3, but --run_agat_metrics is enabled"
-
-            if (params.run_interproscan && !protein_path)
-                error "Sample ${row.sample} is missing protein, but --run_interproscan is enabled"
-
-            tuple(meta, gff_path, protein_path)
-        }
-        .set { sample_ch }
-
-    gff_ch = sample_ch
-        .filter { meta, gff_path, protein_path -> gff_path }
-        .map { meta, gff_path, protein_path -> tuple(meta, gff_path) }
-
-    protein_ch = sample_ch
-        .filter { meta, gff_path, protein_path -> protein_path }
-        .map { meta, gff_path, protein_path -> tuple(meta, protein_path) }
-
-    // Singletons
-    ensembl_genes_repo = file(params.ensembl_genes_repo)
-    agat_parser = params.agat_parser ? file(params.agat_parser) : ''
-    interpro_parser = params.interpro_parser \
-        ? file(params.interpro_parser) \
-        : ''
-
-    // Optional: feature levels YAML
-    feature_levels_yaml = params.feature_levels \
-        ? file(params.feature_levels) \
-        : file("${ensembl_genes_repo}/src/python/ensembl/genes/annotation_qc/config/feature_levels.yaml")
-
-    // Run AGAT metrics
-    if (params.run_agat_metrics) {
-        agat = AGAT_METRICS(
-            gff_ch,
-            feature_levels_yaml,
-            ensembl_genes_repo,
-            agat_parser
-        )
-
-        agat.genebuild_csv.view { meta, f ->
-            "Genebuild metrics for ${meta.id}: ${f}"
-        }
-    }
-
-    // Run InterProScan
-    if (params.run_interproscan) {
-        interpro = INTERPRO_SCAN(
-            protein_ch,
-            params.database,
-            params.data_file_path,
-            params.ensembl_genes_repo,
-            interpro_parser
-        )
-    }
+    QC(
+        annotation_ch,
+        params.mode,
+        feature_levels_yaml,
+        params.database,
+        params.data_file_path,
+        params.diamond_reference_proteins,
+        params.diamond_reference_db
+    )
 }

--- a/pipelines/qc/modules/agat/parse_agat.nf
+++ b/pipelines/qc/modules/agat/parse_agat.nf
@@ -1,42 +1,29 @@
-
 process AGAT_PARSE {
-
     tag { meta.id }
-    label 'process_light'
+    label 'qc_parser'
     publishDir "${params.outdir}/qc/agat", mode: 'copy', overwrite: true,
         pattern: "*_genebuild.csv"
 
-
     input:
-        // from AGAT_RUN_STATS
         tuple val(meta), path(stats_txt)
-        // path to the ensembl-genes repo containing parse_agat.py
-        val ensembl_genes_repo
-        // optional explicit parser path
-        val agat_parser
-        val  feature_levels_yaml
 
     output:
-        tuple val(meta), path("${meta.sample ?: meta.id ?: stats_txt.simpleName.replaceFirst(/_agat_stats$/, '')}_agat_stats_genebuild.csv"), emit: genebuild_csv
-        path "versions.yml", emit: versions
-
-    when:
-        task.ext.when == null || task.ext.when
+        tuple val(meta), path("*_agat_stats_genebuild.csv"), emit: genebuild_csv
+        path 'versions.yml', emit: versions
 
     script:
         def stem = meta.sample ?: meta.id ?: stats_txt.simpleName.replaceFirst(/_agat_stats$/, '')
         def out_csv = "${stem}_agat_stats_genebuild.csv"
-        def parser = agat_parser ?: "${ensembl_genes_repo}/src/python/ensembl/genes/annotation_qc/parsers/parse_agat.py"
         def args = task.ext.args ?: ''
         """
-        python ${parser} \\
-            --input_txt ${stats_txt} \\
-            --output ${out_csv} \\
+        annotation-qc parse-agat \
+            --input_txt ${stats_txt} \
+            --output ${out_csv} \
             ${args}
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            python: \$(python --version 2>&1 | awk '{print \$2}')
+            qc_parser: annotation-qc
         END_VERSIONS
         """
 
@@ -47,7 +34,7 @@ process AGAT_PARSE {
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            python: \$(python --version 2>&1 | awk '{print \$2}')
+            qc_parser: annotation-qc
         END_VERSIONS
         """
 }

--- a/pipelines/qc/modules/agat/run_agat_stats.nf
+++ b/pipelines/qc/modules/agat/run_agat_stats.nf
@@ -5,18 +5,18 @@ process AGAT_RUN_STATS {
         pattern: "*_agat_stats.txt"
     container 'docker://quay.io/biocontainers/agat:1.7.0--pl5321hdfd78af_0'
 
+    // AGAT reads feature_levels.yaml from this path. The pipeline owns the
+    // configuration so users do not need to provide a host path.
     containerOptions {
-        feature_levels_yaml ?
-            "-B ${feature_levels_yaml.resolve()}:/usr/local/lib/perl5/site_perl/auto/share/dist/AGAT/feature_levels.yaml:ro" :
-            ""
+        "-B ${file(feature_levels_yaml)}:/usr/local/lib/perl5/site_perl/auto/share/dist/AGAT/feature_levels.yaml:ro"
     }
 
     input:
         tuple val(meta), path(gff3)
-        val  feature_levels_yaml
+        val feature_levels_yaml
 
     output:
-        tuple val(meta), path("${meta.sample ?: meta.id ?: gff3.simpleName}_agat_stats.txt"), emit: stats_txt
+        tuple val(meta), path("*_agat_stats.txt"), emit: stats_txt
         path "versions.yml", emit: versions
 
     when:

--- a/pipelines/qc/modules/agat/strip_gff_regions.nf
+++ b/pipelines/qc/modules/agat/strip_gff_regions.nf
@@ -6,7 +6,7 @@ process STRIP_GFF_REGIONS {
         tuple val(meta), path(gff3)
 
     output:
-        tuple val(meta), path("${meta.sample ?: meta.id ?: gff3.simpleName}.no_region.gff3"), emit: cleaned_gff
+        tuple val(meta), path("*.no_region.gff3"), emit: cleaned_gff
         path "versions.yml", emit: versions
 
     script:

--- a/pipelines/qc/modules/diamond/blastp.nf
+++ b/pipelines/qc/modules/diamond/blastp.nf
@@ -1,0 +1,43 @@
+process DIAMOND_BLASTP {
+    tag { meta.id }
+    label 'process_high'
+    container 'community.wave.seqera.io/library/diamond:2.1.24--61a5af76160d103f'
+    publishDir "${params.outdir}/qc/diamond", mode: 'copy', overwrite: true
+
+    input:
+        tuple val(meta), path(query_protein)
+        path diamond_db
+
+    output:
+        tuple val(meta), path("*_diamond.tsv"), emit: hits
+        path 'versions.yml', emit: versions
+
+    script:
+        def out = "${meta.id}_diamond.tsv"
+        """
+        diamond blastp \
+            --query ${query_protein} \
+            --db ${diamond_db} \
+            --threads ${task.cpus} \
+            --evalue 1e-5 \
+            --max-target-seqs 1 \
+            --outfmt 6 qseqid sseqid pident length qstart qend qlen qcovhsp sstart send slen evalue bitscore \
+            --out ${out}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            diamond: \$(diamond version | sed 's/^diamond version //')
+        END_VERSIONS
+        """
+
+    stub:
+        def out = "${meta.id}_diamond.tsv"
+        """
+        touch ${out}
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            diamond: 2.1.24
+        END_VERSIONS
+        """
+}

--- a/pipelines/qc/modules/diamond/prep_diamond_db.nf
+++ b/pipelines/qc/modules/diamond/prep_diamond_db.nf
@@ -1,0 +1,34 @@
+process PREP_DIAMOND_DB {
+    tag { 'reference' }
+    label 'process_medium'
+    container 'community.wave.seqera.io/library/diamond:2.1.24--61a5af76160d103f'
+    publishDir "${params.outdir}/qc/diamond", mode: 'copy', overwrite: true,
+        pattern: 'reference.dmnd'
+
+    input:
+        path ref_protein_faa
+
+    output:
+        path 'reference.dmnd', emit: db
+        path 'versions.yml', emit: versions
+
+    script:
+        """
+        diamond makedb --in ${ref_protein_faa} --db reference
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            diamond: \$(diamond version | sed 's/^diamond version //')
+        END_VERSIONS
+        """
+
+    stub:
+        """
+        touch reference.dmnd
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            diamond: 2.1.24
+        END_VERSIONS
+        """
+}

--- a/pipelines/qc/modules/interpro/interpro_stats.nf
+++ b/pipelines/qc/modules/interpro/interpro_stats.nf
@@ -1,46 +1,41 @@
-
 process PROCESS_INTERPRO {
-
     tag { meta.id }
-    label 'process_light'
+    label 'qc_parser'
     publishDir "${params.outdir}/qc/interpro", mode: 'copy', overwrite: true
 
     input:
         tuple val(meta), path(interpro_tsv), path(query_protein)
-        val ensembl_genes_repo
-        val interpro_parser
 
     output:
-        tuple val(meta), path("${meta.sample ?: meta.id ?: interpro_tsv.simpleName.replaceFirst(/\\.tsv$/, '')}_hits.tsv"), emit: interpro_stats_tsv
-        path "versions.yml", emit: versions
+        tuple val(meta), path("*_hits.tsv"), emit: interpro_stats_tsv
+        path 'versions.yml', emit: versions
 
     script:
-        def stem   = meta.sample ?: meta.id ?: interpro_tsv.simpleName.replaceFirst(/\\.tsv$/, '')
+        def stem = meta.sample ?: meta.id ?: interpro_tsv.simpleName.replaceFirst(/\.tsv$/, '')
         def out_dir = "${stem}_interpro_stats"
         def out_tsv = "${stem}_hits.tsv"
-        def parser = interpro_parser ?: "${ensembl_genes_repo}/src/python/ensembl/genes/annotation_qc/parsers/interpro.py"
         """
-        python ${parser} \\
-            --input_tsv ${interpro_tsv} \\
-            --output ${out_dir} \\
+        annotation-qc parse-interpro \
+            --input_tsv ${interpro_tsv} \
+            --output ${out_dir} \
             --query_protein ${query_protein}
 
         mv ${out_dir}/interpro_hit_summary.tsv ${out_tsv}
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            python: \$(python --version 2>&1 | awk '{print \$2}')
+            qc_parser: annotation-qc
         END_VERSIONS
         """
 
     stub:
-        def stem = meta.sample ?: meta.id ?: interpro_tsv.simpleName.replaceFirst(/\\.tsv$/, '')
+        def stem = meta.sample ?: meta.id ?: interpro_tsv.simpleName.replaceFirst(/\.tsv$/, '')
         """
         touch ${stem}_hits.tsv
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
-            python: 3.11.0
+            qc_parser: annotation-qc
         END_VERSIONS
         """
 }

--- a/pipelines/qc/modules/interpro/run_interpro.nf
+++ b/pipelines/qc/modules/interpro/run_interpro.nf
@@ -16,7 +16,7 @@ process INTERPRO_RUN {
         val data_file_path
 
     output:
-        tuple val(meta), path("${meta.sample ?: meta.id ?: protein.simpleName}.tsv"), emit: stats_txt
+        tuple val(meta), path("*.tsv"), emit: stats_txt
         path "versions.yml", emit: versions
 
     when:

--- a/pipelines/qc/modules/sequence/prep_aa_fasta.nf
+++ b/pipelines/qc/modules/sequence/prep_aa_fasta.nf
@@ -7,7 +7,7 @@ process PREP_AA_FASTA {
         tuple val(meta), path(genome_fasta), path(gff3)
 
     output:
-        tuple val(meta), path("*.faa"), emit: aa_fasta
+        tuple val(meta), path("*.clean.faa"), emit: aa_fasta
         path 'versions.yml', emit: versions
 
     script:
@@ -21,7 +21,7 @@ process PREP_AA_FASTA {
                 gsub(/[^ACDEFGHIKLMNPQRSTVWY]/, "X", sequence)
                 print sequence
             }
-        ' ${meta.id}.raw.faa > ${meta.id}.faa
+        ' ${meta.id}.raw.faa > ${meta.id}.clean.faa
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/pipelines/qc/modules/sequence/prep_aa_fasta.nf
+++ b/pipelines/qc/modules/sequence/prep_aa_fasta.nf
@@ -1,0 +1,33 @@
+process PREP_AA_FASTA {
+    tag { meta.id }
+    label 'process_medium'
+    container 'community.wave.seqera.io/library/gffread:0.12.7--33b95f1cfcc0e572'
+
+    input:
+        tuple val(meta), path(genome_fasta), path(gff3)
+
+    output:
+        tuple val(meta), path("*.faa"), emit: aa_fasta
+        path 'versions.yml', emit: versions
+
+    script:
+        """
+        gffread ${gff3} -g ${genome_fasta} -x ${meta.id}.cds.fa -y ${meta.id}.faa
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            gffread: \$(gffread --version 2>&1 | sed 's/^gffread v//')
+        END_VERSIONS
+        """
+
+    stub:
+        """
+        touch ${meta.id}.faa
+        touch ${meta.id}.cds.fa
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            gffread: 0.12.7
+        END_VERSIONS
+        """
+}

--- a/pipelines/qc/modules/sequence/prep_aa_fasta.nf
+++ b/pipelines/qc/modules/sequence/prep_aa_fasta.nf
@@ -12,7 +12,16 @@ process PREP_AA_FASTA {
 
     script:
         """
-        gffread ${gff3} -g ${genome_fasta} -x ${meta.id}.cds.fa -y ${meta.id}.faa
+        gffread ${gff3} -g ${genome_fasta} -x ${meta.id}.cds.fa -y ${meta.id}.raw.faa
+
+        awk '
+            /^>/ { print; next }
+            {
+                sequence = toupper(\$0)
+                gsub(/[^ACDEFGHIKLMNPQRSTVWY]/, "X", sequence)
+                print sequence
+            }
+        ' ${meta.id}.raw.faa > ${meta.id}.faa
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":

--- a/pipelines/qc/nextflow.config
+++ b/pipelines/qc/nextflow.config
@@ -1,24 +1,33 @@
 // Inherit base configuration (resources, error handling, reporting)
 includeConfig '../../nextflow.config'
 
+// Require syntax supported by current Nextflow releases.
+nextflow.enable.strict = true
+
 plugins {
     id 'nf-schema@2.2.0'
 }
 
 params {
-    outdir             = './results'
-    input_csv          = null   // path to the sample CSV
-    feature_levels     = null
-    ensembl_genes_repo = null  // path to local checkout of ensembl-genes
-    agat_parser        = null  // optional explicit path to parse_agat.py; otherwise derived from ensembl_genes_repo
-    run_agat_metrics   = false
-    run_interproscan   = false
-    database           = 'Pfam'
-    data_file_path     = '/nfs/production/flicek/ensembl/shared_data/interproscan-5.78-109.0/data' // path to local database for interproscan
-    interpro_parser    = null // optional explicit path to interpro_parser.py; otherwise derived from ensembl_genes_repo
+    outdir                    = './results'
+    input_csv                 = null
+    mode                      = null
+    database                  = 'Pfam'
+    data_file_path            = null
+    diamond_reference_proteins = null
+    diamond_reference_db       = null
 }
 
 process {
+
+    withLabel: qc_parser {
+        // Use :latest while the annotation-QC container is under development;
+        // pin this to the matching SHA when the pipeline is versioned.
+        container = 'dockerhub.ebi.ac.uk/ensembl_genebuild/ensembl-genes-containers/ensembl-genes-qc-dev:latest'
+        cpus = 1
+        memory = '4.GB'
+        time = '2.h'
+    }
 
     withName: AGAT_RUN_STATS {
         cpus = 1
@@ -49,8 +58,10 @@ profiles {
         process {
             executor = 'slurm'
         }
+
         singularity {
             enabled = true
+            autoMounts = false
         }
     }
 
@@ -59,6 +70,19 @@ profiles {
         process {
             executor = 'local'
             maxForks = 2
+            stageInMode = 'copy'
+
+            withName: 'INTERPRO_RUN' {
+                cpus = 1
+                memory = '4.GB'
+                time = '1.h'
+            }
+
+            withName: 'DIAMOND_BLASTP' {
+                cpus = 1
+                memory = '4.GB'
+                time = '1.h'
+            }
         }
     }
 }

--- a/pipelines/qc/nextflow_schema.json
+++ b/pipelines/qc/nextflow_schema.json
@@ -1,56 +1,79 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "title": "QC Pipeline Parameters",
-    "description": "Parameter schema for the QC pipeline",
-    "type": "object",
-    "properties": {
-        "input_csv": {
-            "type": "string",
-            "description": "Path to a CSV file with at least sample, gff3, and protein columns"
-        },
-        "ensembl_genes_repo": {
-            "type": "string",
-            "description": "Path to a local ensembl-genes checkout"
-        },
-        "feature_levels": {
-            "type": ["string", "null"],
-            "description": "Optional explicit path to feature_levels.yaml"
-        },
-        "agat_parser": {
-            "type": ["string", "null"],
-            "description": "Optional explicit path to parse_agat.py"
-        },
-        "run_agat_metrics": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the AGAT metrics branch"
-        },
-        "run_interproscan": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable the InterProScan branch"
-        },
-        "data_file_path": {
-            "type": ["string", "null"],
-            "description": "Optional explicit path to InterProScan data library"
-        },
-        "database": {
-            "type": "string",
-            "description": "Optional database to run InterProScan on (default: Pfam)"
-        },
-        "interpro_parser": {
-            "type": ["string", "null"],
-            "description": "Optional explicit path to interpro_parser.py"
-        },
-        "outdir": {
-            "type": "string",
-            "default": "./results",
-            "description": "Output directory"
-        },
-        "tracedir": {
-            "type": ["string", "null"],
-            "description": "Directory for Nextflow execution reports and trace files"
-        }
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Annotation QC pipeline parameters",
+  "description": "Run one or more QC analyses from a genome and GFF3 annotation manifest.",
+  "type": "object",
+  "properties": {
+    "input_csv": {
+      "type": "string",
+      "format": "file-path",
+      "exists": true,
+      "pattern": "^\\S+\\.csv$",
+      "description": "CSV containing sample, genome_fasta, and gff3 columns."
     },
-    "required": ["input_csv", "ensembl_genes_repo"]
+    "mode": {
+      "type": "string",
+      "enum": ["agat", "interproscan", "diamond", "combined"],
+      "description": "QC analysis to run. combined runs all available analyses."
+    },
+    "database": {
+      "type": "string",
+      "enum": [
+        "TIGRFAM", "SFLD", "SUPERFAMILY", "PANTHER", "Gene3D", "Hamap",
+        "ProSiteProfiles", "Coils", "SMART", "CDD", "PRINTS", "PIRSR",
+        "ProSitePatterns", "AntiFam", "Pfam", "MobiDBLite", "PIRSF"
+      ],
+      "default": "Pfam",
+      "description": "InterProScan application database."
+    },
+    "data_file_path": {
+      "type": "string",
+      "format": "directory-path",
+      "exists": true,
+      "description": "Local InterProScan data directory."
+    },
+    "diamond_reference_proteins": {
+      "type": "string",
+      "format": "file-path",
+      "exists": true,
+      "description": "Reference protein FASTA used to build the Diamond database."
+    },
+    "diamond_reference_db": {
+      "type": "string",
+      "format": "file-path",
+      "exists": true,
+      "description": "Existing Diamond database file. When supplied, the reference protein FASTA is not used."
+    },
+    "outdir": {
+      "type": "string",
+      "default": "./results",
+      "description": "Output directory."
+    },
+    "tracedir": {
+      "type": "string",
+      "description": "Directory for Nextflow execution reports and trace files."
+    }
+  },
+  "required": ["input_csv", "mode"],
+  "allOf": [
+    {
+      "if": {
+        "properties": {"mode": {"enum": ["interproscan", "combined"]}},
+        "required": ["mode"]
+      },
+      "then": {"required": ["data_file_path"]}
+    },
+    {
+      "if": {
+        "properties": {"mode": {"enum": ["diamond", "combined"]}},
+        "required": ["mode"]
+      },
+      "then": {
+        "oneOf": [
+          {"required": ["diamond_reference_db"]},
+          {"required": ["diamond_reference_proteins"]}
+        ]
+      }
+    }
+  ]
 }

--- a/pipelines/qc/subworkflows/agat/agat_stats.nf
+++ b/pipelines/qc/subworkflows/agat/agat_stats.nf
@@ -1,37 +1,26 @@
-
 include { AGAT_RUN_STATS } from '../../modules/agat/run_agat_stats.nf'
 include { STRIP_GFF_REGIONS } from '../../modules/agat/strip_gff_regions.nf'
-include { AGAT_PARSE     } from '../../modules/agat/parse_agat.nf'
+include { AGAT_PARSE } from '../../modules/agat/parse_agat.nf'
 
 workflow AGAT_METRICS {
-
     take:
-        // [meta, gff3]
+        // Channel of [meta, gff3] tuples.
         gff3_ch
-        // feature_levels yaml (may be empty)
+        // Ensembl-owned AGAT feature definitions used by the statistics step.
         feature_levels_yaml
-        // path to ensembl-genes checkout
-        ensembl_genes_repo
-        // optional explicit parse_agat.py path
-        agat_parser
 
     main:
         stripped_gff = STRIP_GFF_REGIONS(gff3_ch)
-
         agat_txt = AGAT_RUN_STATS(
             stripped_gff.cleaned_gff,
             feature_levels_yaml
         )
-
         genebuild = AGAT_PARSE(
-            agat_txt.stats_txt,
-            ensembl_genes_repo,
-            agat_parser,
-            feature_levels_yaml
+            agat_txt.stats_txt
         )
 
     emit:
-        stats_txt     = agat_txt.stats_txt
+        stats_txt = agat_txt.stats_txt
         genebuild_csv = genebuild.genebuild_csv
-        versions      = stripped_gff.versions.mix(agat_txt.versions).mix(genebuild.versions)
+        versions = stripped_gff.versions.mix(agat_txt.versions).mix(genebuild.versions)
 }

--- a/pipelines/qc/subworkflows/diamond/diamond_protein_validation.nf
+++ b/pipelines/qc/subworkflows/diamond/diamond_protein_validation.nf
@@ -1,0 +1,28 @@
+include { PREP_DIAMOND_DB } from '../../modules/diamond/prep_diamond_db.nf'
+include { DIAMOND_BLASTP } from '../../modules/diamond/blastp.nf'
+
+workflow DIAMOND_PROTEIN_VALIDATION {
+    take:
+        protein_ch
+        ref_protein_faa
+        ref_diamond_db
+
+    main:
+        if (ref_diamond_db) {
+            diamond_db = channel.value(file(ref_diamond_db))
+            database_versions = channel.empty()
+        } else {
+            reference_db = PREP_DIAMOND_DB(file(ref_protein_faa))
+            diamond_db = reference_db.db.collect()
+            database_versions = reference_db.versions
+        }
+
+        hits = DIAMOND_BLASTP(
+            protein_ch,
+            diamond_db
+        )
+
+    emit:
+        diamond_tsv = hits.hits
+        versions = database_versions.mix(hits.versions)
+}

--- a/pipelines/qc/subworkflows/interpro/interproscan.nf
+++ b/pipelines/qc/subworkflows/interpro/interproscan.nf
@@ -1,15 +1,11 @@
-
 include { INTERPRO_RUN } from '../../modules/interpro/run_interpro.nf'
 include { PROCESS_INTERPRO } from '../../modules/interpro/interpro_stats.nf'
 
 workflow INTERPRO_SCAN {
-
     take:
         protein_ch
         database
         data_file_path
-        ensembl_genes_repo
-        interpro_parser
 
     main:
         interpro_run = INTERPRO_RUN(
@@ -17,13 +13,9 @@ workflow INTERPRO_SCAN {
             database,
             data_file_path
         )
-
         interpro_stats_input = interpro_run.stats_txt.join(protein_ch)
-
         interpro_stats = PROCESS_INTERPRO(
-            interpro_stats_input,
-            ensembl_genes_repo,
-            interpro_parser
+            interpro_stats_input
         )
 
     emit:

--- a/pipelines/qc/workflows/qc.nf
+++ b/pipelines/qc/workflows/qc.nf
@@ -1,0 +1,65 @@
+include { AGAT_METRICS } from '../subworkflows/agat/agat_stats.nf'
+include { INTERPRO_SCAN } from '../subworkflows/interpro/interproscan.nf'
+include { DIAMOND_PROTEIN_VALIDATION } from '../subworkflows/diamond/diamond_protein_validation.nf'
+include { PREP_AA_FASTA } from '../modules/sequence/prep_aa_fasta.nf'
+
+workflow QC {
+
+    take:
+        annotation_ch
+        mode
+        feature_levels_yaml
+        database
+        data_file_path
+        diamond_reference_proteins
+        diamond_reference_db
+
+    main:
+        // Each row supplies the shared annotation inputs. A precomputed protein
+        // FASTA is used when present; otherwise it is derived with gffread.
+        samples = annotation_ch.map { row ->
+            def meta = [id: row[0], sample: row[0]]
+            def protein = row.size() > 3 && row[3] ? file(row[3]) : null
+            tuple(meta, file(row[1]), file(row[2]), protein)
+        }
+
+        gff_ch = samples.map { meta, _genome_fasta, gff3, _protein -> tuple(meta, gff3) }
+
+        if (mode in ['agat', 'combined']) {
+            AGAT_METRICS(
+                gff_ch,
+                feature_levels_yaml
+            )
+        }
+
+        if (mode in ['interproscan', 'diamond', 'combined']) {
+            supplied_proteins = samples
+                .filter { _meta, _genome_fasta, _gff3, protein -> protein }
+                .map { meta, _genome_fasta, _gff3, protein -> tuple(meta, protein) }
+
+            samples_to_derive = samples
+                .filter { _meta, _genome_fasta, _gff3, protein -> !protein }
+                .map { meta, genome_fasta, gff3, _protein ->
+                    tuple(meta, genome_fasta, gff3)
+                }
+
+            derived_proteins = PREP_AA_FASTA(samples_to_derive)
+            protein_ch = supplied_proteins.mix(derived_proteins.aa_fasta)
+        }
+
+        if (mode in ['interproscan', 'combined']) {
+            INTERPRO_SCAN(
+                protein_ch,
+                database,
+                data_file_path
+            )
+        }
+
+        if (mode in ['diamond', 'combined']) {
+            DIAMOND_PROTEIN_VALIDATION(
+                protein_ch,
+                diamond_reference_proteins,
+                diamond_reference_db
+            )
+        }
+}


### PR DESCRIPTION
In this PR I change how we call from ensembl-genes to using containers built through ensembl-genes-containers. 

I also adjust the input spec to rely on a manifest file that can be validated with nf-schema and add qc modes. 

I made this version strict syntax compliant. 