### PR TITLE
Improve template strict syntax and guidance

### DIFF
--- a/.codex/skills/ensembl-nf-build-component/SKILL.md
+++ b/.codex/skills/ensembl-nf-build-component/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: ensembl-nf-build-component
+description: Create or modify a conformant Nextflow DSL2 module or subworkflow in ensembl-genes-nf. Use for process wrappers, channel contracts, module reuse, subworkflow composition, containers, resource labels, versions files, and stubs.
+---
+
+# Build a Conformant Nextflow Component
+
+Read `docs/MODULES.md`, `modules/reference_example.nf`, and the closest real component before changing code. Prefer the real pipeline's established interface where it is more specific than the template.
+
+## Module contract
+
+- Give a module one primary tool responsibility. Split unrelated tools into separate modules and compose them in a subworkflow.
+- Accept and emit `tuple val(meta), path(...)` for sample-associated files; retain the same `meta` map without mutation. Create a new map with `meta + [...]` only when metadata must change.
+- Set a meaningful `tag`, resource `label`, version-pinned container or conda environment, and an explicit `publishDir` under `${params.outdir}` when outputs are user-facing.
+- Emit named result channels and `path "versions.yml", emit: versions`. Capture the real tool version in `script` and a fixed representative value in `stub`.
+- Define optional arguments and output prefix in `task.ext` with safe defaults. Use `task.ext.when` for externally configured conditional execution instead of embedding pipeline policy in the module.
+- Make the `stub` create every declared output with the same naming rules as the real script.
+
+## Subworkflow contract
+
+- Declare `take:`, `main:`, and `emit:` explicitly. Keep public input/output tuple shapes in comments.
+- Use descriptive channel names. Apply `join`, `groupTuple`, `collect`, `branch`, or `ifEmpty` only after checking the expected cardinality and metadata keys.
+- Expose useful result and version channels; avoid hiding outputs required by later workflow stages.
+- Keep process resource settings and tool arguments in configuration, not hardcoded in the subworkflow.
+
+## Verification
+
+Parse the owning pipeline and exercise the smallest stub-mode workflow that reaches the component. Inspect the output tuple names and generated `versions.yml` before declaring the work complete. Keep fixes scoped: do not reformat unrelated modules or replace a working local convention with an abstract template.

--- a/.codex/skills/ensembl-nf-build-component/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-build-component/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Build Ensembl NF Component"
+  short_description: "Create conformant Nextflow components"
+  default_prompt: "Use $ensembl-nf-build-component to add this Nextflow module or subworkflow."

--- a/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
+++ b/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
@@ -18,7 +18,7 @@ Inspect the target pipeline and its nearest working analogue before editing. Tre
 
 ## Work deliberately
 
-1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
+1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/NEXTFLOW_REQUIREMENTS.md`, `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
 2. Trace every changed input and output channel end-to-end. Name emitted channels for their content, not their position.
 3. Reuse resource labels from `config/resources.config`, explicit tool versions, and an appropriate container/conda definition.
 4. Keep outputs under `${params.outdir}` and preserve standard execution reporting through the inherited root configuration.
@@ -29,8 +29,9 @@ Inspect the target pipeline and its nearest working analogue before editing. Tre
 Run the narrowest relevant commands first:
 
 ```bash
+nextflow lint -o concise .
 nextflow config pipelines/<pipeline>/main.nf
-nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+nextflow run pipelines/<pipeline>/main.nf -stub-run -profile local --outdir /tmp/<pipeline>-stub
 ```
 
 Use the pipeline's established test command when it exists. If an external tool, image, reference, or test input prevents execution, report the exact command, blocker, and the unverified surface; never claim a real run passed from a parse-only check.

--- a/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
+++ b/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ensembl-nf-implement-pipeline
+description: Implement or extend a pipeline in the ensembl-genes-nf repository. Use when adding a pipeline, workflow entry point, pipeline-local configuration, schema parameter, or cross-component feature while preserving this repository's DSL2 architecture and testing conventions.
+---
+
+# Implement an Ensembl Nextflow Pipeline
+
+Inspect the target pipeline and its nearest working analogue before editing. Treat `pipelines/example/` as the learning template and an existing pipeline as the implementation precedent; do not copy a template's unfinished TODOs into production code.
+
+## Preserve the architecture
+
+- Keep pipeline-owned code beneath `pipelines/<name>/`: `main.nf`, `nextflow.config`, modules, subworkflows, resources, and tests/examples as needed.
+- Use DSL2 and let `main.nf` compose named subworkflows. Keep tool processes out of the entry point except for truly pipeline-specific minimal work.
+- Use one primary bioinformatics tool per module. Put orchestration and channel transformations in subworkflows.
+- Pass sample data as tuples beginning with `meta`; preserve `meta` through outputs. State tuple shapes in comments at public subworkflow boundaries.
+- Keep reusable modules configurable through `task.ext` and pipeline configuration. Put a pipeline-only parameter, resource override, or profile in that pipeline's `nextflow.config`; do not modify root configuration for a one-pipeline need.
+- Add or update user-facing parameters in the pipeline schema/configuration together. Validate required inputs early, before work is launched.
+
+## Work deliberately
+
+1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
+2. Trace every changed input and output channel end-to-end. Name emitted channels for their content, not their position.
+3. Reuse resource labels from `config/resources.config`, explicit tool versions, and an appropriate container/conda definition.
+4. Keep outputs under `${params.outdir}` and preserve standard execution reporting through the inherited root configuration.
+5. Add a small, representative stub-mode path for changed orchestration. Do not add generated results, `.nextflow*`, `work/`, or container caches to version control.
+
+## Finish with evidence
+
+Run the narrowest relevant commands first:
+
+```bash
+nextflow config pipelines/<pipeline>/main.nf
+nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+```
+
+Use the pipeline's established test command when it exists. If an external tool, image, reference, or test input prevents execution, report the exact command, blocker, and the unverified surface; never claim a real run passed from a parse-only check.

--- a/.codex/skills/ensembl-nf-implement-pipeline/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-implement-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement Ensembl NF Pipeline"
+  short_description: "Build pipelines using this repository design"
+  default_prompt: "Use $ensembl-nf-implement-pipeline to implement this pipeline change."

--- a/.codex/skills/ensembl-nf-verify-change/SKILL.md
+++ b/.codex/skills/ensembl-nf-verify-change/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ensembl-nf-verify-change
+description: Review and validate a change in ensembl-genes-nf before handoff. Use for Nextflow syntax/configuration checks, stub runs, channel-contract review, schema/configuration consistency, output hygiene, and focused repository change review.
+---
+
+# Verify an Ensembl Nextflow Change
+
+Establish the changed surface with `git diff --check`, `git status --short`, and a targeted diff. Treat unrelated dirty files as user work: do not stage, delete, or edit them.
+
+## Review against repository rules
+
+- Confirm DSL2 entry points compose subworkflows and that a module has one primary tool responsibility.
+- Trace each changed tuple from producer to consumer: `meta` is retained, file arity matches, and `emit` names match their consumers.
+- Confirm process settings use a resource label, version-pinned container/conda, `task.ext` defaults where applicable, a `versions.yml` output, and a faithful stub block.
+- Confirm pipeline-specific params, tool arguments, resource overrides, and profiles live in `pipelines/<name>/nextflow.config`; root configuration remains shared only.
+- Confirm declared output filenames, `publishDir` patterns, and stub outputs agree. Generated results, `work/`, `.nextflow*`, caches, and local reference paths must stay out of the diff.
+
+## Test in layers
+
+Run checks from cheapest to most representative:
+
+```bash
+git diff --check
+nextflow config pipelines/<pipeline>/main.nf
+nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+```
+
+Use a targeted existing test where one exists, for example:
+
+```bash
+cd pipelines/riboseq && ./test_unique_reads.sh
+```
+
+Use an isolated temporary output directory for ad-hoc runs. State exactly which layers passed and which were not attempted, including missing binaries, containers, references, or input data. A syntax/configuration check is not an execution result.

--- a/.codex/skills/ensembl-nf-verify-change/SKILL.md
+++ b/.codex/skills/ensembl-nf-verify-change/SKILL.md
@@ -21,8 +21,9 @@ Run checks from cheapest to most representative:
 
 ```bash
 git diff --check
+nextflow lint -o concise .
 nextflow config pipelines/<pipeline>/main.nf
-nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+nextflow run pipelines/<pipeline>/main.nf -stub-run -profile local --outdir /tmp/<pipeline>-stub
 ```
 
 Use a targeted existing test where one exists, for example:

--- a/.codex/skills/ensembl-nf-verify-change/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-verify-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Ensembl NF Change"
+  short_description: "Review and test Nextflow changes safely"
+  default_prompt: "Use $ensembl-nf-verify-change to validate this repository change."

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 This repository provides templates and examples to help you build Nextflow pipelines:
 
-- **Pipeline templates** - Production-ready patterns and structure
+- **Pipeline templates** - Practical starting patterns and structure
 - **Example workflows** - Working examples from simple to complex
 - **Module templates** - Reusable process definitions
 - **Comprehensive documentation** - Guides, patterns, and best practices
-- **Advanced patterns** - Entry point system for complex workflows
+- **Additional patterns** - Optional approaches for more complex workflows
 
 ## Quick Start
 
@@ -23,14 +23,13 @@ Explore the templates by running the example workflows:
 cd pipelines/example
 
 # Run the simplest example (single process)
-nextflow run workflows/simple_workflow.nf -stub --outdir results
+nextflow run workflows/simple_workflow.nf -stub-run --outdir results
 
 # Run the main workflow (subworkflows chained together)
-nextflow run main.nf -stub --outdir results
+nextflow run main.nf -stub-run -profile test
 
-# Explore the advanced entry point system
-cd advanced_entrypoints
-nextflow run main.nf --help
+# Read the repository requirements
+cat ../../docs/NEXTFLOW_REQUIREMENTS.md
 ```
 
 ## Repository Structure
@@ -42,7 +41,7 @@ ensembl-genes-nf/  (template branch)
 │       ├── workflows/    # Example workflows (start here)
 │       ├── subworkflows/ # Subworkflow patterns (parallel, sequential)
 │       ├── modules/      # Process templates
-│       └── advanced_entrypoints/  # Dynamic entry point system
+│       └── assets/            # Deterministic test inputs
 ├── modules/              # Module templates for creating new processes
 ├── subworkflows/         # Subworkflow templates
 ├── config/               # Configuration templates
@@ -96,8 +95,12 @@ The example pipeline demonstrates patterns from simple to complex:
 
 ## Requirements
 
-- Nextflow ≥ 21.04.0 (DSL2)
-- Singularity 
+- Nextflow ≥ 26.04.0 (strict syntax)
+- Java 17 or newer
+- Singularity, Apptainer, Docker, or Conda depending on the pipeline profile
+
+See [docs/NEXTFLOW_REQUIREMENTS.md](docs/NEXTFLOW_REQUIREMENTS.md) for the
+repository contract and validation commands.
 
 ## Branch Structure
 
@@ -121,4 +124,3 @@ Contributions to improve templates and documentation are welcome! Consider:
 ## License
 
 [Add license information]
-

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -236,7 +236,7 @@ Root defaults
 
 **Key principle**: More specific settings override more general ones
 
-### Do's
+### Useful defaults
 
 - **Use resource labels** - Start with standard labels, override only when necessary
 
@@ -248,15 +248,15 @@ Root defaults
 
 - **Provide sensible defaults** - Pipelines should run with zero configuration
 
-### Don'ts
+### Things to consider
 
-- **Don't hardcode in modules** - Resources, paths, and arguments belong in config
+- **Avoid hardcoding in modules when settings may vary** - Resources, paths, and arguments are often easier to manage in config
 
-- **Don't edit root config for one pipeline** - Use pipeline-specific config instead
+- **Prefer pipeline-specific config for pipeline-specific settings** - Edit the root config when a setting is genuinely shared
 
-- **Don't duplicate settings** - If it's in a resource label, don't repeat in process
+- **Limit duplicated settings** - If a resource label already expresses a value, repeating it in a process can make changes harder to track
 
-- **Don't commit local paths** - Use parameters or relative paths
+- **Avoid committing local paths** - Parameters or relative paths are usually more portable
 
 ## Configuration Inheritance Example
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -4,12 +4,15 @@ How to design and structure Nextflow process modules in this repository.
 
 ## Module Philosophy
 
-**A module is a single, reusable process** that wraps one primary bioinformatics tool. Modules should be:
+**A module is usually a single, reusable process** that wraps one primary
+bioinformatics tool. This is a helpful default for keeping code composable;
+small related shell steps can be kept together when splitting them would make
+the interface harder to understand. When using a separate module, aim for:
 
-- **Generic** - Work across different pipelines and use cases
-- **Configurable** - Parameters come from config, not hardcoded
-- **Consistent** - Follow standard patterns for inputs, outputs, and metadata
-- **Self-documenting** - Include versions, clear naming, and structure
+- **Appropriate reuse** - Work across different pipelines when reuse is useful
+- **Configurable** - Put changeable settings in config or `task.ext` where that helps
+- **Consistent** - Follow familiar patterns for inputs, outputs, and metadata
+- **Self-documenting** - Include versions, clear naming, and enough structure to maintain it
 
 ## Core Module Structure
 
@@ -81,7 +84,7 @@ tool --sample ${meta.id} --input ${reads} --output ${prefix}.bam
 
 **Best practices**:
 ```groovy
-- Always include meta.id
+- Include `meta.id` when sample identity needs to be tracked
 - Use meta for sample attributes, not file properties
 - Don't modify meta in place, create new: meta + [new_field: value]
 - Keep meta structure consistent across modules
@@ -237,7 +240,7 @@ process {
 ```
 
 **Benefits**:
-- Module code never needs editing for parameter changes
+- Module code often does not need editing when settings are exposed through configuration
 - Different pipelines can use same module differently
 - Configuration separate from implementation
 
@@ -278,7 +281,7 @@ tool --input ${input} --output ${prefix}_${suffix}.txt
 
 **Best practices**:
 ```groovy
-- Always use meta.id in output names
+- Use `meta.id` in output names when it provides useful sample-level uniqueness
 - Use task.ext.prefix for customisation
 - Check for input/output name conflicts
 - Use consistent naming patterns across modules
@@ -372,7 +375,10 @@ aligner ${args} input.fq | sorter ${args2} > output.bam
 """
 ```
 
-## Anti-Patterns to Avoid
+## Patterns to use carefully
+
+The following examples are common sources of maintenance problems, but context
+matters. Treat them as warning signs to review rather than absolute bans.
 
 - **Hardcoded parameters**
 ```groovy
@@ -445,19 +451,19 @@ path "versions.yml",            emit: versions
 
 See [modules/minimal_example.nf](../modules/minimal_example.nf) for a TODO-annotated template and [modules/reference_example.nf](../modules/reference_example.nf) for a comprehensive example with extensive comments.
 
-## Best Practices Summary
+## Recommended defaults
 
-- **Always include meta map** in inputs and outputs for tracking
+- **Include a meta map** when sample identity or attributes need to travel with data
 
-- **Always emit versions.yml** for reproducibility
+- **Emit versions.yml** when tool-version reporting matters for reproducibility
 
-- **Always include stub block** for fast testing
+- **Include a stub block** when fast structural testing is useful
 
 - **Use resource labels** rather than hardcoding resources
 
 - **Configure via ext.args** not hardcoded parameters
 
-- **One primary tool per module** - compose with subworkflows
+- **One primary tool per module when practical** - compose with subworkflows when that improves clarity
 
 - **Use specific container versions** not 'latest'
 

--- a/docs/NEXTFLOW_REQUIREMENTS.md
+++ b/docs/NEXTFLOW_REQUIREMENTS.md
@@ -1,0 +1,44 @@
+# Nextflow requirements
+
+This repository targets Nextflow 26.04 or newer, Java 17 or newer, and strict
+syntax. Nextflow 26.04 enables the strict parser by default.
+
+The following is the recommended baseline for maintained pipelines. It is a
+starting point rather than a checklist that every pipeline must follow without
+exception. If a pipeline needs a different choice, document the reason in its
+README and keep the test and user-facing behavior clear.
+
+The usual defaults are:
+
+1. Use DSL2 with an explicit entry `workflow`.
+2. Put executable statements inside a process, workflow, or function.
+3. Validate parameters inside the entry workflow, where practical.
+4. Prefer `channel` over the deprecated `Channel` factory.
+5. Prefer `script:` for process commands and declare process inputs explicitly.
+6. Keep high-level branching in workflows and tool execution in modules when
+   that makes the code easier to reuse.
+7. Pass reference files and helper scripts as process inputs when they are part
+   of the task's data or need to be staged reproducibly.
+8. Provide a stub implementation for workflows that need quick structural
+   testing, with outputs that match the real process.
+9. Keep the schema, README, defaults, and test profile broadly consistent.
+
+## Checks
+
+From the repository root:
+
+```bash
+nextflow lint -o concise .
+```
+
+From the example pipeline:
+
+```bash
+cd pipelines/example
+nextflow lint -o concise .
+nextflow run main.nf -stub-run -profile test
+```
+
+For a new pipeline, a small test profile and deterministic input under the
+pipeline directory are useful defaults. Avoid production data and
+host-specific paths in tests where possible.

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -402,7 +402,7 @@ meta = [
 include { MY_SUBWORKFLOW } from './subworkflows/my_subworkflow'
 
 workflow {
-    test_input = Channel.of(
+    test_input = channel.of(
         [[id: 'test1'], file('test1.txt')],
         [[id: 'test2'], file('test2.txt')]
     )

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,226 +1,65 @@
-# Getting Started with the Example Pipeline
+# Quick start
 
-This guide walks you through the example pipeline, starting with the simplest concepts and progressively building to more advanced patterns.
+The example pipeline is the executable starting point for a new pipeline.
+It targets Nextflow 26.04 or newer and uses strict syntax.
 
-## Your First Workflow
+## Run the example
 
-Start by running a single process workflow to understand the basic structure.
 ```bash
 cd pipelines/example
-nextflow run workflows/simple_workflow.nf -stub --outdir simple_results
+nextflow lint -o concise .
+nextflow run main.nf -stub-run -profile test
 ```
 
-**What it does:** Runs one process on two samples
+The test profile uses the deterministic input in `assets/input.txt`, runs two
+sample records through two tools, combines the results, and counts lines. The
+outputs are written below `results/test`.
 
-**Key concepts:**
-- Basic workflow structure
-- Creating input channels
-- Running a single process
-
-**Explore the code:**
-- [workflows/simple_workflow.nf](workflows/simple_workflow.nf) - Main workflow
-- [modules/tool_a.nf](modules/tool_a.nf) - The process definition
-
----
-
-## Working with Subworkflows
-
-Once you're comfortable with basic workflows, learn how to organize code into reusable subworkflows.
-```bash
-# Two subworkflows chained together
-nextflow run workflows/two_subworkflows.nf -stub --outdir results
-
-# Example with multiple subworkflows
-nextflow run workflows/minimal_example.nf -stub --outdir results
-```
-
-**What it does:**
-- First subworkflow: Runs tools in parallel
-- Second subworkflow: Combines results and counts lines
-
-**Key concepts:**
-- Including and chaining subworkflows
-- Passing channels between subworkflows
-- Parallel and sequential execution patterns
-
-**Explore the code:**
-- [workflows/two_subworkflows.nf](workflows/two_subworkflows.nf) - Chaining custom subworkflows
-- [subworkflows/minimal_subworkflow_example.nf](subworkflows/minimal_subworkflow_example.nf) - Parallel execution
-- [subworkflows/simple_sequential_example.nf](subworkflows/simple_sequential_example.nf) - Sequential execution
-
-**Additional resources:**
-- [PATTERNS.md](PATTERNS.md) - 12 common Nextflow patterns
-- [workflows.md](workflows.md) - Detailed workflow documentation
-
----
-
-## Dynamic Entry Points
-
-For more complex pipelines, you may want automatic workflow resumption based on existing outputs.
-```bash
-cd advanced_entrypoints
-
-# See available entry points
-nextflow run main.nf --help
-
-# Automatic detection: runs full workflow if no outputs exist
-nextflow run main.nf -stub --outdir results
-
-# Automatic resume: detects existing outputs and skips completed steps
-rm -rf results/combined results/line_counts
-nextflow run main.nf -stub --outdir results
-# Detects existing tool outputs and resumes from combine step
-
-# Manual override: force a specific entry point
-nextflow run main.nf -stub --entry_point RUN_TOOLS --outdir results
-nextflow run main.nf -stub --entry_point COMBINE_AND_COUNT --outdir results
-```
-
-**Key concepts:**
-- Automatic entry point detection based on existing outputs
-- Dependency validation before execution
-- Manual entry point override when needed
-- Clear error messages for missing dependencies
-
-**Explore the code:**
-- [advanced_entrypoints/main.nf](../pipelines/example/advanced_entrypoints/main.nf) - Dynamic entry point workflow
-- [advanced_entrypoints/lib/EntryPoints.groovy](../pipelines/example/advanced_entrypoints/lib/EntryPoints.groovy) - Entry point registry
-- [advanced_entrypoints/docs/advanced_design.md](../pipelines/example/advanced_entrypoints/docs/advanced_design.md) - System design documentation
-
----
-
-## Quick Reference
-
-### File Structure
-```
-pipelines/example/
-├── workflows/              # Simple examples (START HERE)
-│   ├── simple_workflow.nf
-│   ├── minimal_example.nf
-│   └── two_subworkflows.nf
-├── subworkflows/           # Reusable subworkflows
-│   ├── run_tools.nf
-│   └── combine_and_count.nf
-├── modules/                # Individual processes
-│   ├── tool_a.nf
-│   ├── tool_b.nf
-│   └── ...
-├── advanced_entrypoints/   # Advanced: Entry point system
-│   ├── main.nf            # Dynamic entry points
-│   └── lib/EntryPoints.groovy
-└── main.nf                 # Simple: Two subworkflows
-```
-
-### Common Commands
+For the smallest example:
 
 ```bash
-# Run in stub mode (fast, for testing)
-nextflow run <workflow.nf> -stub --outdir <dir>
-
-# Run for real
-nextflow run <workflow.nf> --outdir <dir>
-
-# Generate workflow diagram
-nextflow run <workflow.nf> -with-dag flowchart.html
-
-# Resume from cached results
-nextflow run <workflow.nf> -resume
-
-# See workflow report
-nextflow run <workflow.nf> -with-report report.html
+nextflow run workflows/simple_workflow.nf -stub-run --outdir results/simple
 ```
 
-### Suggested Learning Path
+## Copy the structure
 
-Follow this progression to build your understanding:
+Use this layout for a real pipeline:
 
-1. Run and explore `simple_workflow.nf` to understand basic workflow structure
-2. Run `minimal_example.nf` to see how subworkflows connect
-3. Review [PATTERNS.md](PATTERNS.md) for common patterns you'll use
-4. Explore the entry point system in `advanced_entrypoints/`
-5. Read the design documentation to understand advanced concepts
+```text
+pipelines/my-pipeline/
+├── main.nf                 # validate parameters and call the entry workflow
+├── nextflow.config         # plugins, defaults, and test/profile settings
+├── nextflow_schema.json    # parameter contract
+├── assets/                 # small deterministic test inputs and references
+├── workflows/              # orchestration and conditional branching
+├── subworkflows/           # reusable chains of modules
+└── modules/                # one process/tool per file
+```
 
----
+Start a module with `modules/minimal_example.nf`. Use
+`modules/reference_example.nf` when you need dynamic arguments, optional
+outputs, and retry configuration.
 
-## Creating Your Own
+As a default, keep named parameters in `main.nf`. Validate and normalize them
+there, then pass explicit channels and values into workflows and subworkflows.
+This can keep reusable components independent of one pipeline's parameter names
+and schema. It is a design choice rather than a restriction: direct parameter
+access may be fine for genuinely pipeline-wide settings.
+See [workflows.md](workflows.md#keep-parameter-ownership-at-the-entrypoint)
+for the rationale and a concrete example.
 
-### 1. Create a New Process
+## Development loop
 
-Copy the template:
+1. Add or change the schema and defaults.
+2. Update the README and test profile.
+3. Keep orchestration in workflows and tool commands in modules.
+4. Make the stub create every declared output.
+5. Run strict lint and the smallest stub workflow.
+
 ```bash
-cp modules/minimal_example.nf modules/my_tool.nf
+nextflow lint -o concise .
+nextflow run main.nf -stub-run -profile test
 ```
 
-Edit and replace TODOs:
-- Process name
-- Container URL
-- Input/output channels
-- Command to run
-
-### 2. Create a New Subworkflow
-
-```groovy
-include { MY_TOOL } from '../modules/my_tool'
-
-workflow MY_SUBWORKFLOW {
-    take:
-    input_ch  // channel: [ val(meta), path(file) ]
-
-    main:
-    MY_TOOL(input_ch)
-
-    emit:
-    results  = MY_TOOL.out.results
-    versions = MY_TOOL.out.versions
-}
-```
-
-### 3. Create a New Workflow
-
-```groovy
-#!/usr/bin/env nextflow
-nextflow.enable.dsl = 2
-
-include { MY_SUBWORKFLOW } from '../subworkflows/my_subworkflow'
-
-params.outdir = 'results'
-
-workflow {
-    // Create input
-    Channel.of([id: 'sample1'])
-        .map { meta -> [meta, file('input.txt')] }
-        .set { input_ch }
-
-    // Run subworkflow
-    MY_SUBWORKFLOW(input_ch)
-}
-```
-
----
-
-## Additional Resources
-
-- **Workflow patterns:** [PATTERNS.md](PATTERNS.md) - 12 common patterns
-- **Workflow examples:** [workflows.md](workflows.md) - Detailed examples
-- **Entry point design:** [advanced_entrypoints/docs/advanced_design.md](../pipelines/example/advanced_entrypoints/docs/advanced_design.md)
-- **Nextflow docs:** https://nextflow.io/docs/latest/
-- **nf-core guidelines:** https://nf-co.re/docs/guidelines
-
----
-
-## Tips
-
-- Always start in `-stub` mode for fast iteration
-- Use descriptive channel names (not `ch1`, `ch2`)
-- Document your channel structure with comments
-- Test each subworkflow independently
-- Use `groupTuple()` to collect files per sample
-
-- Don't hardcode paths (use `params`)
-- Don't modify `meta` in place (create new)
-- Don't forget `emit:` block in subworkflows
-- Don't forget to handle empty channels
-
----
-
-**Ready to dive in?** Start with [workflows/simple_workflow.nf](workflows/simple_workflow.nf)!
+See [NEXTFLOW_REQUIREMENTS.md](NEXTFLOW_REQUIREMENTS.md) for the repository
+contract and [PATTERNS.md](PATTERNS.md) for reusable dataflow patterns.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Complete documentation for the example pipeline.
 
 New to this pipeline? Start here:
 
-- **[QUICK_START.md](QUICK_START.md)** - Step-by-step guide from basics to advanced
+- **[QUICK_START.md](QUICK_START.md)** - Step-by-step guide from lint to stub run
 - **[INDEX.md](INDEX.md)** - Complete documentation index
 
 ## Reference Guides
@@ -21,5 +21,5 @@ New to this pipeline? Start here:
 
 **Quick Links:**
 - Back to [main README](../README.md)
-- [Example workflows](../workflows/)
-- [Advanced entry points](../advanced_entrypoints/)
+- [Example pipeline](../pipelines/example/)
+- [Nextflow requirements](NEXTFLOW_REQUIREMENTS.md)

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -4,14 +4,70 @@ How to design and structure workflows and subworkflows in this repository.
 
 ## Workflow Philosophy
 
-**Workflows orchestrate, modules execute.** Workflows and subworkflows should focus on connecting components, not implementing logic.
+**A useful default is: workflows orchestrate and modules execute.** This keeps
+the dataflow easy to follow, but small pipelines may reasonably combine a few
+layers when introducing more files would add noise.
+
+## Keep parameter ownership at the entrypoint
+
+The entrypoint (`main.nf`) is usually the best place to own named pipeline
+parameters. It validates
+the schema, resolves parameter-dependent files and defaults, and translates
+those values into explicit channels or values before calling the workflow
+layer. This is the boundary between the user's configuration and the
+pipeline's dataflow.
+
+For reusable named workflows and subworkflows, it is usually clearer not to
+reach into `params` for inputs. Instead, declare dependencies in `take:` and
+pass them as arguments. For example:
+
+```groovy
+// main.nf
+workflow {
+    validateParameters()
+    samples_ch = channel.fromPath(params.input)
+    ANALYSIS(samples_ch, params.mode, file(params.reference))
+}
+
+// subworkflows/analysis.nf
+workflow ANALYSIS {
+    take:
+    samples_ch
+    mode
+    reference
+
+    main:
+    if (mode == 'combined') {
+        TOOL_A(samples_ch, reference)
+        TOOL_B(samples_ch, reference)
+    }
+}
+```
+
+This reduces coupling between a reusable subworkflow and a particular
+parameter name, schema, or command-line interface. Another pipeline can reuse
+`ANALYSIS` with a different manifest or parameter schema, provided it supplies
+the same explicit inputs. It also makes dependencies visible in the call site,
+which can make testing, documentation, and later changes easier. Direct
+`params` access can still be reasonable for genuinely pipeline-wide settings;
+the important distinction is whether the dependency is intentional and clear.
+
+The intended direction is therefore:
+
+```text
+named parameters → main.nf → workflows → subworkflows → modules
+```
+
+Each layer can narrow configuration into explicit dataflow. Parameters are
+often easiest to manage at the edge, while reusable components generally work
+best with declared inputs.
 
 ### Key Principles
 
-1. **Workflows are coordinators** - They connect modules and manage data flow
-2. **Keep workflows thin** - Business logic belongs in modules, not workflows
-3. **Subworkflows are reusable** - Design for use across multiple pipelines
-4. **Clear hierarchy** - Main workflow → Subworkflows → Modules
+1. **Workflows coordinate** - They connect modules and manage data flow
+2. **Keep responsibilities visible** - Put logic where it is easiest to test and understand
+3. **Make subworkflows reusable when useful** - Reuse is a benefit, not a requirement
+4. **Use a clear hierarchy when the pipeline needs it** - Main workflow → subworkflows → modules
 
 ## Workflow vs Subworkflow
 
@@ -31,7 +87,7 @@ params.outdir = 'results'
 
 workflow {
     // Create input
-    input_ch = Channel.fromPath(params.input)
+    input_ch = channel.fromPath(params.input)
 
     // Orchestrate subworkflows
     SUBWORKFLOW_A(input_ch)
@@ -39,7 +95,7 @@ workflow {
 }
 ```
 
-**Characteristics**:
+**Typical characteristics**:
 - Entry point for `nextflow run`
 - No `take` or `emit` blocks (unnamed workflow)
 - Defines pipeline-level parameters
@@ -69,13 +125,13 @@ workflow PROCESS_SAMPLES {
 }
 ```
 
-**Characteristics**:
+**Typical characteristics**:
 - Named workflow with `take` and `emit` blocks
 - Reusable across multiple pipelines
 - Encapsulates a logical unit of work
 - Clear inputs and outputs
 
-**When to create a subworkflow**:
+**A subworkflow is especially useful when**:
 - Logic is reused across multiple pipelines
 - Grouping related processes makes sense conceptually
 - You want to test a component independently
@@ -249,7 +305,7 @@ workflow {
 
 ### Subworkflow Outputs
 
-**Always emit what downstream needs**:
+**Emit what downstream needs**:
 
 ```groovy
 workflow MY_SUBWORKFLOW {
@@ -267,7 +323,7 @@ workflow MY_SUBWORKFLOW {
     // Intermediate outputs (if needed downstream)
     intermediate = PROCESS_A.out.results
 
-    // Always emit versions for all processes
+    // Emit versions for all processes when version tracking is part of the pipeline contract
     versions = PROCESS_A.out.versions
         .concat(PROCESS_B.out.versions)
 }
@@ -548,7 +604,7 @@ workflow ALIGN {
 **Subworkflow Design**:
 - Clear take/emit blocks with types
 - One logical unit of work per subworkflow
-- Always emit versions
+- Emit versions when they are part of the pipeline's reproducibility contract
 - Design for reusability
 
 **Channel Operations**:

--- a/modules/minimal_example.nf
+++ b/modules/minimal_example.nf
@@ -12,15 +12,20 @@ process EXAMPLE_MODULE {
 
     // TODO: Update publishDir path to reflect your module's output directory name
     publishDir "${params.outdir}/example_module",
-        saveAs: 'example_module/${meta.id}_${filename}'
+        mode: 'copy',
+        pattern: '*.txt'
 
     // TODO: Update input channels to match your tool's requirements
     input:
-    tuple val(meta), path(input_file)
+    tuple val(meta), path(input_files)
+    path reference
+    val mode
+    val prefix
+    val args
 
     // TODO: Update output files and emit names to match what your tool produces
     output:
-    tuple val(meta), path("${prefix}.txt"),             emit: results 
+    tuple val(meta), path('*.txt'),                      emit: results
     path "versions.yml",                                emit: versions 
     
     when:
@@ -37,7 +42,7 @@ process EXAMPLE_MODULE {
         --mode ${mode} \\
         --threads ${task.cpus} \\
         --output ${prefix}.txt \\
-        ${args}
+        ${args ?: ''}
 
     # Capture versions for reproducibility
     # TODO: Update version extraction command to match your tool's --version output format
@@ -51,8 +56,6 @@ process EXAMPLE_MODULE {
     stub:
     """
     touch ${prefix}.txt
-    touch ${prefix}.log
-
     # TODO: Update tool name and version number in stub
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/reference_example.nf
+++ b/modules/reference_example.nf
@@ -41,10 +41,10 @@ process EXAMPLE_MODULE {
     val mode                                // Required parameter for tool execution
     
     output:
-    tuple val(meta), path("${prefix}.txt"),             emit: results // keep meta in output for tracking
-    tuple val(meta), path("${prefix}.log"),             emit: logs
-    tuple val(meta), path("${prefix}_report.html"),     emit: reports, optional: true
-    tuple val(meta), path("${prefix}_stats.json"),      emit: stats,   optional: true
+    tuple val(meta), path('*.txt'),                      emit: results // keep meta in output for tracking
+    tuple val(meta), path('*.log'),                      emit: logs
+    tuple val(meta), path('*_report.html'),              emit: reports, optional: true
+    tuple val(meta), path('*_stats.json'),               emit: stats,   optional: true
     path "versions.yml",                                emit: versions // capture tool versions for reproducibility
     
     when:
@@ -64,7 +64,6 @@ process EXAMPLE_MODULE {
     // inputs should be defined in the input block above. Everything else should be
     // defined here and passed through the task.ext object.
     def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def is_paired = meta.single_end ? false : true
     def input_files = is_paired ? "${reads[0]} ${reads[1]}" : "${reads}"
@@ -96,8 +95,7 @@ process EXAMPLE_MODULE {
     stub:
     //  Allows rapid testing of workflow logic without running
     // expensive computations. Use 'nextflow run -stub' to validate your pipeline
-    // structure before committing to long-running jobs.    def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
+    // structure before committing to long-running jobs.
     def prefix = task.ext.prefix ?: "${meta.id}"
     
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -14,6 +14,7 @@ manifest {
     homePage        = 'https://github.com/ensembl/ensembl-genes-nf'
     description     = 'Collection of bioinformatics pipelines'
     version         = '0.1.0'
+    nextflowVersion = '!>=26.04'
 }
 
 // Default process settings - applied to all processes unless overridden
@@ -24,7 +25,6 @@ process {
     time   = '2.h'
     
     // Error handling strategy
-    errorStrategy = 'retry'                // Retry failed jobs once
     maxRetries    = 1                      // Maximum number of retries
     maxErrors     = '-1'                   // Don't stop pipeline on individual job failures
 
@@ -35,7 +35,6 @@ process {
     //          eg. 'bowtie x.fq <index> | samtools sort -b -O out.bam' 
     //             will fail if bowtie fails even if samtools somehow outputs
     //             exit status 0
-    shell = ['/bin/bash', '-euo', 'pipefail']
 }
 
 // Global params that are inherited by pipelines - typically for logging runs 
@@ -69,9 +68,8 @@ dag {
 // I had this in a profile but decided it should be the default and can be overwritten with profiles 
 // if we want to support non-cluster execution with Docker/Conda 
 singularity {
-    singularity {
-        enabled = true
-        autoMounts = true
-        cacheDir = '/hps/nobackup/flicek/ensembl/genebuild/singularity_cache'  // Suggested path for shared cache
-    }
+    enabled = true
+    autoMounts = false
+    cacheDir = '/hps/nobackup/flicek/ensembl/genebuild/singularity_cache'
+    runOptions = '--cleanenv'
 }

--- a/pipelines/example/README.md
+++ b/pipelines/example/README.md
@@ -6,7 +6,7 @@ Minimal Nextflow pipeline demonstrating subworkflow patterns.
 
 ```bash
 # Run the main workflow (2 tools + combine + count)
-nextflow run main.nf -stub --outdir results
+nextflow run main.nf -stub-run -profile test
 ```
 
 This runs two tools in parallel, combines their outputs, and counts lines.
@@ -21,7 +21,7 @@ This runs two tools in parallel, combines their outputs, and counts lines.
 │   └── subworkflow_example.nf   # Same as main.nf (for reference)
 ├── subworkflows/                 # 2 reusable subworkflow examples
 ├── modules/                      # 7 example processes
-├── advanced_entrypoints/         # Advanced: Entry point system
+├── assets/                       # Deterministic test inputs
 └── docs/                         # All documentation
 ```
 
@@ -31,7 +31,7 @@ This runs two tools in parallel, combines their outputs, and counts lines.
 A single process workflow - demonstrates the basics.
 
 ```bash
-nextflow run workflows/simple_workflow.nf -stub --outdir results
+nextflow run workflows/simple_workflow.nf -stub-run --outdir results
 ```
 
 **Output**: `tool_a/` (1 tool, 2 samples)
@@ -40,21 +40,10 @@ nextflow run workflows/simple_workflow.nf -stub --outdir results
 Two subworkflows chained together (also available as `workflows/subworkflow_example.nf`).
 
 ```bash
-nextflow run main.nf -stub --outdir results
+nextflow run main.nf -stub-run -profile test
 ```
 
 **Output**: `tool_a/`, `tool_b/`, `combined/`, `line_counts/` (2 tools + processing)
-
-### Advanced Entry Points (advanced_entrypoints/)
-Dynamic entry point system with automatic workflow resumption.
-
-```bash
-cd advanced_entrypoints
-nextflow run main.nf --help
-nextflow run main.nf -stub --outdir results
-```
-
-**Output**: All 4 tools + combine + count with automatic entry point detection
 
 ## Where to Start
 
@@ -62,7 +51,9 @@ nextflow run main.nf -stub --outdir results
 
 **Familiar with workflows?** Explore `main.nf` to see subworkflow patterns.
 
-**Building complex pipelines?** Check out `advanced_entrypoints/` for the entry point system.
+**Building complex pipelines?** Use the workflow/subworkflow/module separation
+shown in `main.nf` and the `workflows/`, `subworkflows/`, and `modules/`
+directories.
 
 ## Documentation
 
@@ -73,4 +64,52 @@ All documentation is in **[docs/](docs/)**:
 
 ## Parameters
 
-- `--outdir` - Output directory (default: `'results'`)
+- `--input` - Input file (default: `assets/input.txt`)
+- `--outdir` - Output directory (default: `./results`)
+
+The schema, defaults, README, and workflow are intentionally kept in sync so
+this directory can be copied as a starting point for a real pipeline.
+
+## Why `main.nf`, `workflows/`, and `subworkflows/` are separate
+
+The separation keeps command-line parameters at the boundary of the pipeline.
+`main.nf` is responsible for validating named parameters such as
+`params.input`, resolving files and defaults, and converting them into the
+channels and values that the pipeline actually needs. The workflow layer then
+decides which stages run and how those inputs are connected.
+
+For reusable subworkflows, it is usually clearer not to reach directly into
+named parameters. A subworkflow can instead receive explicit inputs in its
+`take:` block, such as `samples_ch`,
+`reference`, or `mode`, and expose explicit outputs in its `emit:` block. This
+means a subworkflow does not silently depend on a parameter name, a particular
+schema, or a particular entrypoint. A different pipeline can reuse the same
+subworkflow with a different parameter schema, or call it with a channel built
+from a manifest, database, or another upstream stage.
+
+In practice, the dependency flow is:
+
+```text
+named CLI/config parameters
+        │
+        ▼
+main.nf: validate, resolve, normalize
+        │  explicit channels and values
+        ▼
+workflows/: choose stages and branches
+        │  explicit subworkflow inputs
+        ▼
+subworkflows/: compose reusable analysis units
+        │  explicit module inputs
+        ▼
+modules/: execute one tool or transformation
+```
+
+For example, a QC entrypoint may turn `--mode combined` and an annotation
+manifest into `annotation_ch`, `database`, and `data_file_path`. The QC
+subworkflow can then take those values explicitly without knowing whether they
+came from command-line parameters, a profile, or another workflow. This keeps
+parameter dependencies manageable at the edge instead of imposing one
+pipeline's parameter names on every reusable component. Direct parameter access
+can still be appropriate for genuinely global settings; the useful question is
+whether the dependency is intentional and easy to see.

--- a/pipelines/example/assets/input.txt
+++ b/pipelines/example/assets/input.txt
@@ -1,0 +1,1 @@
+input data for the Nextflow template example

--- a/pipelines/example/main.nf
+++ b/pipelines/example/main.nf
@@ -2,13 +2,13 @@
 
 nextflow.enable.dsl = 2
 
-include { validateParameters } from 'plugin/nf-schema'
+nextflow.enable.strict = true
 
-// Validate parameters against schema
-validateParameters()
+include { validateParameters } from 'plugin/nf-schema'
 
 include { SUBWORKFLOW_EXAMPLE } from './workflows/subworkflow_example.nf'
 
 workflow {
-    SUBWORKFLOW_EXAMPLE()
+    validateParameters()
+    SUBWORKFLOW_EXAMPLE(file(params.input))
 }

--- a/pipelines/example/nextflow.config
+++ b/pipelines/example/nextflow.config
@@ -1,4 +1,18 @@
-// strongly recommended but not required 
+nextflow.enable.strict = true
+
 plugins {
     id 'nf-schema@2.2.0'
+}
+
+params {
+    input  = "${projectDir}/assets/input.txt"
+    outdir = './results'
+}
+
+profiles {
+    test {
+        process.executor = 'local'
+        params.input = "${projectDir}/assets/input.txt"
+        params.outdir = './results/test'
+    }
 }

--- a/pipelines/example/nextflow_schema.json
+++ b/pipelines/example/nextflow_schema.json
@@ -1,11 +1,13 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Example Pipeline Parameters",
     "description": "Parameter schema for the example pipeline",
     "type": "object",
     "properties": {
       "input": {
         "type": "string",
+        "format": "file-path",
+        "exists": true,
         "description": "Path to input file"
       },
       "outdir": {

--- a/pipelines/example/workflows/simple_workflow.nf
+++ b/pipelines/example/workflows/simple_workflow.nf
@@ -11,6 +11,8 @@
 
 nextflow.enable.dsl = 2
 
+nextflow.enable.strict = true
+
 include { TOOL_A } from '../modules/tool_a'
 
 // Parameters with defaults
@@ -18,7 +20,7 @@ params.outdir = 'simple_results'
 
 workflow {
     // Create a simple input channel
-    Channel.of(
+    channel.of(
         [id: 'sample1'],
         [id: 'sample2']
     )

--- a/pipelines/example/workflows/subworkflow_example.nf
+++ b/pipelines/example/workflows/subworkflow_example.nf
@@ -10,20 +10,22 @@
 
 nextflow.enable.dsl = 2
 
+nextflow.enable.strict = true
+
 include { MINIMAL_SUBWORKFLOW_EXAMPLE } from '../subworkflows/minimal_subworkflow_example'
 include { SIMPLE_SEQUENTIAL_EXAMPLE } from '../subworkflows/simple_sequential_example'
 
-params.outdir = 'results'
-
 workflow SUBWORKFLOW_EXAMPLE {
+    take:
+        input_file
+
+    main:
     // Create input
-    Channel.of(
+    channel.of(
         [id: 'sample1'],
         [id: 'sample2']
     )
     .map { meta ->
-        def input_file = file("${workflow.workDir}/input.txt")
-        input_file.text = "input data"
         [meta, input_file]
     }
     .set { input_ch }


### PR DESCRIPTION
Updates the reusable Nextflow template with stricter syntax, clearer workflow/module guidance, and refreshed example pipeline documentation.

This PR contains the template changes from commit 28dab98.