### PR TITLE
Add reusable Ensembl Nextflow agent skills

### DIFF
--- a/.codex/skills/ensembl-nf-build-component/SKILL.md
+++ b/.codex/skills/ensembl-nf-build-component/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: ensembl-nf-build-component
+description: Create or modify a conformant Nextflow DSL2 module or subworkflow in ensembl-genes-nf. Use for process wrappers, channel contracts, module reuse, subworkflow composition, containers, resource labels, versions files, and stubs.
+---
+
+# Build a Conformant Nextflow Component
+
+Read `docs/MODULES.md`, `modules/reference_example.nf`, and the closest real component before changing code. Prefer the real pipeline's established interface where it is more specific than the template.
+
+## Module contract
+
+- Give a module one primary tool responsibility. Split unrelated tools into separate modules and compose them in a subworkflow.
+- Accept and emit `tuple val(meta), path(...)` for sample-associated files; retain the same `meta` map without mutation. Create a new map with `meta + [...]` only when metadata must change.
+- Set a meaningful `tag`, resource `label`, version-pinned container or conda environment, and an explicit `publishDir` under `${params.outdir}` when outputs are user-facing.
+- Emit named result channels and `path "versions.yml", emit: versions`. Capture the real tool version in `script` and a fixed representative value in `stub`.
+- Define optional arguments and output prefix in `task.ext` with safe defaults. Use `task.ext.when` for externally configured conditional execution instead of embedding pipeline policy in the module.
+- Make the `stub` create every declared output with the same naming rules as the real script.
+
+## Subworkflow contract
+
+- Declare `take:`, `main:`, and `emit:` explicitly. Keep public input/output tuple shapes in comments.
+- Use descriptive channel names. Apply `join`, `groupTuple`, `collect`, `branch`, or `ifEmpty` only after checking the expected cardinality and metadata keys.
+- Expose useful result and version channels; avoid hiding outputs required by later workflow stages.
+- Keep process resource settings and tool arguments in configuration, not hardcoded in the subworkflow.
+
+## Verification
+
+Parse the owning pipeline and exercise the smallest stub-mode workflow that reaches the component. Inspect the output tuple names and generated `versions.yml` before declaring the work complete. Keep fixes scoped: do not reformat unrelated modules or replace a working local convention with an abstract template.

--- a/.codex/skills/ensembl-nf-build-component/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-build-component/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Build Ensembl NF Component"
+  short_description: "Create conformant Nextflow components"
+  default_prompt: "Use $ensembl-nf-build-component to add this Nextflow module or subworkflow."

--- a/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
+++ b/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
@@ -18,7 +18,7 @@ Inspect the target pipeline and its nearest working analogue before editing. Tre
 
 ## Work deliberately
 
-1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
+1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/NEXTFLOW_REQUIREMENTS.md`, `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
 2. Trace every changed input and output channel end-to-end. Name emitted channels for their content, not their position.
 3. Reuse resource labels from `config/resources.config`, explicit tool versions, and an appropriate container/conda definition.
 4. Keep outputs under `${params.outdir}` and preserve standard execution reporting through the inherited root configuration.
@@ -29,8 +29,9 @@ Inspect the target pipeline and its nearest working analogue before editing. Tre
 Run the narrowest relevant commands first:
 
 ```bash
+nextflow lint -o concise .
 nextflow config pipelines/<pipeline>/main.nf
-nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+nextflow run pipelines/<pipeline>/main.nf -stub-run -profile local --outdir /tmp/<pipeline>-stub
 ```
 
 Use the pipeline's established test command when it exists. If an external tool, image, reference, or test input prevents execution, report the exact command, blocker, and the unverified surface; never claim a real run passed from a parse-only check.

--- a/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
+++ b/.codex/skills/ensembl-nf-implement-pipeline/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ensembl-nf-implement-pipeline
+description: Implement or extend a pipeline in the ensembl-genes-nf repository. Use when adding a pipeline, workflow entry point, pipeline-local configuration, schema parameter, or cross-component feature while preserving this repository's DSL2 architecture and testing conventions.
+---
+
+# Implement an Ensembl Nextflow Pipeline
+
+Inspect the target pipeline and its nearest working analogue before editing. Treat `pipelines/example/` as the learning template and an existing pipeline as the implementation precedent; do not copy a template's unfinished TODOs into production code.
+
+## Preserve the architecture
+
+- Keep pipeline-owned code beneath `pipelines/<name>/`: `main.nf`, `nextflow.config`, modules, subworkflows, resources, and tests/examples as needed.
+- Use DSL2 and let `main.nf` compose named subworkflows. Keep tool processes out of the entry point except for truly pipeline-specific minimal work.
+- Use one primary bioinformatics tool per module. Put orchestration and channel transformations in subworkflows.
+- Pass sample data as tuples beginning with `meta`; preserve `meta` through outputs. State tuple shapes in comments at public subworkflow boundaries.
+- Keep reusable modules configurable through `task.ext` and pipeline configuration. Put a pipeline-only parameter, resource override, or profile in that pipeline's `nextflow.config`; do not modify root configuration for a one-pipeline need.
+- Add or update user-facing parameters in the pipeline schema/configuration together. Validate required inputs early, before work is launched.
+
+## Work deliberately
+
+1. Read the affected `main.nf`, `nextflow.config`, direct modules/subworkflows, and the relevant sections of `docs/MODULES.md`, `docs/PATTERNS.md`, and `docs/CONFIGURATION.md`.
+2. Trace every changed input and output channel end-to-end. Name emitted channels for their content, not their position.
+3. Reuse resource labels from `config/resources.config`, explicit tool versions, and an appropriate container/conda definition.
+4. Keep outputs under `${params.outdir}` and preserve standard execution reporting through the inherited root configuration.
+5. Add a small, representative stub-mode path for changed orchestration. Do not add generated results, `.nextflow*`, `work/`, or container caches to version control.
+
+## Finish with evidence
+
+Run the narrowest relevant commands first:
+
+```bash
+nextflow config pipelines/<pipeline>/main.nf
+nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+```
+
+Use the pipeline's established test command when it exists. If an external tool, image, reference, or test input prevents execution, report the exact command, blocker, and the unverified surface; never claim a real run passed from a parse-only check.

--- a/.codex/skills/ensembl-nf-implement-pipeline/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-implement-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement Ensembl NF Pipeline"
+  short_description: "Build pipelines using this repository design"
+  default_prompt: "Use $ensembl-nf-implement-pipeline to implement this pipeline change."

--- a/.codex/skills/ensembl-nf-verify-change/SKILL.md
+++ b/.codex/skills/ensembl-nf-verify-change/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ensembl-nf-verify-change
+description: Review and validate a change in ensembl-genes-nf before handoff. Use for Nextflow syntax/configuration checks, stub runs, channel-contract review, schema/configuration consistency, output hygiene, and focused repository change review.
+---
+
+# Verify an Ensembl Nextflow Change
+
+Establish the changed surface with `git diff --check`, `git status --short`, and a targeted diff. Treat unrelated dirty files as user work: do not stage, delete, or edit them.
+
+## Review against repository rules
+
+- Confirm DSL2 entry points compose subworkflows and that a module has one primary tool responsibility.
+- Trace each changed tuple from producer to consumer: `meta` is retained, file arity matches, and `emit` names match their consumers.
+- Confirm process settings use a resource label, version-pinned container/conda, `task.ext` defaults where applicable, a `versions.yml` output, and a faithful stub block.
+- Confirm pipeline-specific params, tool arguments, resource overrides, and profiles live in `pipelines/<name>/nextflow.config`; root configuration remains shared only.
+- Confirm declared output filenames, `publishDir` patterns, and stub outputs agree. Generated results, `work/`, `.nextflow*`, caches, and local reference paths must stay out of the diff.
+
+## Test in layers
+
+Run checks from cheapest to most representative:
+
+```bash
+git diff --check
+nextflow config pipelines/<pipeline>/main.nf
+nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+```
+
+Use a targeted existing test where one exists, for example:
+
+```bash
+cd pipelines/riboseq && ./test_unique_reads.sh
+```
+
+Use an isolated temporary output directory for ad-hoc runs. State exactly which layers passed and which were not attempted, including missing binaries, containers, references, or input data. A syntax/configuration check is not an execution result.

--- a/.codex/skills/ensembl-nf-verify-change/SKILL.md
+++ b/.codex/skills/ensembl-nf-verify-change/SKILL.md
@@ -21,8 +21,9 @@ Run checks from cheapest to most representative:
 
 ```bash
 git diff --check
+nextflow lint -o concise .
 nextflow config pipelines/<pipeline>/main.nf
-nextflow run pipelines/<pipeline>/main.nf -stub -profile local --outdir /tmp/<pipeline>-stub
+nextflow run pipelines/<pipeline>/main.nf -stub-run -profile local --outdir /tmp/<pipeline>-stub
 ```
 
 Use a targeted existing test where one exists, for example:

--- a/.codex/skills/ensembl-nf-verify-change/agents/openai.yaml
+++ b/.codex/skills/ensembl-nf-verify-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Ensembl NF Change"
+  short_description: "Review and test Nextflow changes safely"
+  default_prompt: "Use $ensembl-nf-verify-change to validate this repository change."


### PR DESCRIPTION
Adds reusable Codex skills for building components, implementing pipelines, and verifying changes against the Ensembl Nextflow template.

This is based directly on the updated template branch and contains only the skill files.